### PR TITLE
CU-VEUE-2 pin chat form to bottom

### DIFF
--- a/app/javascript/style/chat.scss
+++ b/app/javascript/style/chat.scss
@@ -9,6 +9,7 @@
 .chat-section {
   background-color: color.$white;
   .account-header {
+    margin-bottom: 4rem;
     .comment-section {
       .comment-grid {
         display: flex;
@@ -75,9 +76,14 @@
     }
   }
 
+  .chat-form {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+  }
+
   .message-write {
     border-top: 1px solid color.$gray-light-1;
-    width: 90%;
     .write-area {
       margin-top: 1rem;
       padding: 0rem 0.5rem;

--- a/app/javascript/style/videos.scss
+++ b/app/javascript/style/videos.scss
@@ -3,6 +3,7 @@
 .content-area__left__small {
   border-top-left-radius: 0.625rem;
   border-top-right-radius: 0.625rem;
+  position: relative;
   .stream-area {
     position: relative;
   }

--- a/app/views/shared/_chat.html.haml
+++ b/app/views/shared/_chat.html.haml
@@ -22,7 +22,7 @@
                   = message.body
           - @last_user = message.user
   - if user_signed_in?
-    = form_for ChatMessage.new, remote: true, data: { target: "chat.chatForm" } do |f|
+    = form_for ChatMessage.new, remote: true, html: { class: 'chat-form' }, data: { target: "chat.chatForm" } do |f|
       .message-write
         .write-area
           = f.hidden_field :video_id, value: video.id


### PR DESCRIPTION
This PR is for fixing style of chat message form. This chat form moves from its place i-e bottom when there is no content in messages. But now it is fixed at bottom and its position will not move on the basis of less/more content in messages area.

Issue before fix:
<img width="342" alt="Screenshot 2020-08-25 at 10 42 55 PM" src="https://user-images.githubusercontent.com/23502541/91208910-622a4e00-e724-11ea-8f99-a1c1094817eb.png">

After fix:
<img width="374" alt="Screenshot 2020-08-25 at 10 42 06 PM" src="https://user-images.githubusercontent.com/23502541/91208928-6a828900-e724-11ea-9b9c-c0f03281015b.png">
