### PR TITLE
Fix video height in very wide situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 10-02-2020 - Video Height Bugfix [VEUE-121](https://app.clickup.com/t/8444384/VEUE-121) - @hcatlin
+
 - ##[VEUE-105](https://app.clickup.com/t/8444384/VEUE-105)
   @hcatlin - 10-01-2020
   - ###CHANGED

--- a/app/javascript/style/video/_layout.scss
+++ b/app/javascript/style/video/_layout.scss
@@ -43,10 +43,6 @@ body#videos__show {
       .close-btn {
         display: none;
       }
-
-      .primary-video-area {
-        max-height: 90vh;
-      }
     }
   }
 


### PR DESCRIPTION
This isn’t the IDEAL fix, but at least it will stop the text from sliding under the video frame.

We do need to find a way to limit the total height of the video frame relative to the rest of the screen. Maybe when only the width is more than the height? Or the height is less than the video frame?