### PR TITLE
Properly hide overflowing URL Bar

### DIFF
--- a/app/javascript/style/_global.scss
+++ b/app/javascript/style/_global.scss
@@ -5,6 +5,7 @@ body,
 * {
   font-family: font.$nunito;
   font-weight: font.$normal-weight;
+  min-width: 0;
 }
 
 body {

--- a/app/javascript/style/video/_header_bar.scss
+++ b/app/javascript/style/video/_header_bar.scss
@@ -15,6 +15,13 @@ body#videos__show {
       flex: 1;
       font-size: 1rem;
       border: 1px solid color.$gray-light;
+
+      #address-input {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        text-overflow-ellipsis: color.$gray-light;
+      }
     }
 
     > * {

--- a/app/views/videos/show.html.haml
+++ b/app/views/videos/show.html.haml
@@ -3,7 +3,7 @@
     .primary-video-area
       .primary-video__header{data: {controller: "audience--header-bar"}}
         .primary-video__header__address_bar
-          #address-input{type: "text", disabled: true, data: {target: "audience--header-bar.addressInput"}}
+          #address-input{data: {target: "audience--header-bar.addressInput"}}
         - if current_video.live?
           .widget
             .icon


### PR DESCRIPTION
Previously, our Audience view went haywire when the URL was too long for display.

![image](https://user-images.githubusercontent.com/111/98165558-1a5a3c80-1eb4-11eb-9e70-299588badec1.png)

I've moved to an "..." in the styling. 

Tested in Chrome, FF, and Safari.