### PR TITLE
Use H264 in MediaCapture API

### DIFF
--- a/app/javascript/helpers/broadcast/stream_capturer.ts
+++ b/app/javascript/helpers/broadcast/stream_capturer.ts
@@ -27,7 +27,7 @@ export default class StreamCapturer {
     this.mediaStream.addTrack(this._audioTrack);
 
     this.mediaRecorder = new MediaRecorder(this.mediaStream, {
-      mimeType: "video/webm",
+      mimeType: "video/webm;codecs=H264",
     });
 
     this.mediaRecorder.addEventListener("dataavailable", async (e) => {


### PR DESCRIPTION
After talking with some media encoding experts, I realized that we were using webm+VP9 and then `ffmpeg` was having to do a VP9 => H.264 change to get the data to Mux. So, here we skip the re-encoding by forcing it to use H.264 inside the webm container.