### PR TITLE
Stabilize the Broadcast Spec

### DIFF
--- a/spec/system/broadcast_spec.rb
+++ b/spec/system/broadcast_spec.rb
@@ -76,7 +76,7 @@ describe "Broadcast View" do
       it "should display live messages on broadcaster view" do
         first_message = someone_chatted
         second_message_text = "Cowabunga!"
-        
+
         expect(find(".message-left")).to have_content(first_message.text)
         expect(page).to_not have_content(second_message_text)
         expect(page).to have_content(first_message.user.display_name)


### PR DESCRIPTION
By using find() instead of the page object, this will delay the check until the message appears.

This was causing this spec to fail about 1 in 10 times, and from my local test fully addresses the issue.