### PR TITLE
[VEUE-215] Do Not Eclipse Canvas in Landscape

### DIFF
--- a/app/javascript/style/video/_layout.scss
+++ b/app/javascript/style/video/_layout.scss
@@ -89,12 +89,6 @@ body#videos__show {
       justify-content: flex-end;
     }
 
-    .content-area,
-    #layout-container {
-      height: -webkit-fill-available;
-      width: 100vw;
-    }
-
     .content-area__primary {
       padding-left: env(safe-area-inset-left);
       flex: 1;


### PR DESCRIPTION
By removing these extranious rules, the view now shows up better.

This display size still needs a LOT of tweaks and help, but at least you can see everything for now

![image](https://user-images.githubusercontent.com/111/98605687-dd2aeb80-22b3-11eb-8e42-dd5445f8a8d2.png)
