### PR TITLE
"Change Login Prompt to be One-Time-Code"

### DIFF
--- a/app/views/shared/_login_modal.html.haml
+++ b/app/views/shared/_login_modal.html.haml
@@ -21,7 +21,7 @@
         - elsif @ula.pending_confirmation?
           .form-row Enter the code we just texted you below!
           .form-row
-            %input{type: "text", name: "secret_code"}
+            %input{type: "text", name: "secret_code", autocomplete: "one-time-code"}
             .form-item
               %input{type: 'hidden', name: "session_token_uuid", value: @ula.uuid}
           .form-row


### PR DESCRIPTION
This pull request is referenced on the ticket titled: "Change Login Prompt to be One-Time-Code". 

About the changes I've made: I changed ___login_modal.html.haml_ file on line 24. It was added **autocomplete: "one-time-code"**, since the ticket requested that "when a user is logging in, we send them an SMS with a login code, we should change this to use the autocomplete inputs."