### PR TITLE
[VEUE-192] proof-of-concept for copy-to-clipboard (note several defects)

### DIFF
--- a/app/javascript/controllers/broadcast/browser_controller.ts
+++ b/app/javascript/controllers/broadcast/browser_controller.ts
@@ -32,7 +32,6 @@ export default class extends Controller {
       this.updateState(navigationUpdate);
     };
     ipcRenderer.on("browserView", this.browserViewListener);
-
     this.navigateToAddress();
   }
 

--- a/app/javascript/controllers/broadcast_controller.ts
+++ b/app/javascript/controllers/broadcast_controller.ts
@@ -3,7 +3,10 @@ import { ipcRenderer } from "helpers/electron/ipc_renderer";
 import { Rectangle } from "types/rectangle";
 import VideoMixer from "helpers/broadcast/video_mixer";
 import StreamCapturer from "helpers/broadcast/stream_capturer";
-import { calculateBroadcastArea } from "helpers/broadcast_helpers";
+import {
+  calculateBroadcastArea,
+  copyToClipboard,
+} from "helpers/broadcast_helpers";
 import TimecodeManager from "helpers/broadcast/timecode_manager";
 import { postForm } from "util/fetch";
 import { getCurrentUrl } from "controllers/broadcast/browser_controller";
@@ -112,7 +115,10 @@ export default class extends Controller {
     this.state = "finished";
     this.streamCapturer.stop();
   }
-
+  copyCurrentURLToClipboard(): void {
+    const video_path = window.location.href.replace("broadcasts/", "videos/");
+    copyToClipboard(video_path);
+  }
   pinPage(): void {
     const url = document
       .querySelector("input[data-target='broadcast--browser.addressBar']")

--- a/app/javascript/helpers/broadcast_helpers.ts
+++ b/app/javascript/helpers/broadcast_helpers.ts
@@ -6,6 +6,18 @@ export function getBroadcastElement(): HTMLElement {
   return document.getElementById("broadcast");
 }
 
+export function copyToClipboard(copy_string: string): void {
+  const copy_el = document.createElement("textarea");
+  copy_el.value = copy_string;
+  copy_el.setAttribute("readonly", "");
+  copy_el.style.position = "absolute";
+  copy_el.style.left = "-9999px";
+  document.body.appendChild(copy_el);
+  copy_el.select();
+  document.execCommand("copy");
+  document.body.removeChild(copy_el);
+}
+
 export function calculateBroadcastArea(
   dimensions: Rectangle,
   workArea: Rectangle,

--- a/app/javascript/style/broadcast/_layout.scss
+++ b/app/javascript/style/broadcast/_layout.scss
@@ -91,3 +91,12 @@ textarea {
     }
   }
 }
+
+.btn.copy-to-clipboard {
+  &:hover {
+    cursor: default;
+  }
+  &:active {
+    background-color: color.$red-highlight;
+  }
+}

--- a/app/views/broadcasts/show.html.haml
+++ b/app/views/broadcasts/show.html.haml
@@ -12,5 +12,8 @@
           = svg_tag "cam"
         .btn{data: {action: "click->broadcast--debug#showHideAction"}}
           = svg_tag "toolbox"
+        %button.btn.copy-to-clipboard{data: {action: "click->broadcast#copyCurrentURLToClipboard"}}
+          Copy
+
       .debug-area{data: {target: "broadcast--debug.debugArea"}}
       = render partial: "shared/chat", locals: { video: current_broadcast_video}

--- a/spec/system/broadcast_spec.rb
+++ b/spec/system/broadcast_spec.rb
@@ -110,5 +110,19 @@ describe "Broadcast View" do
         expect(page).to have_content("Pizza time!").once
       end
     end
+
+    describe "copy to clipboard feature" do
+      it "can copy the stream URL to the clipboard while streaming" do
+        page.driver.browser.execute_cdp(
+          "Browser.grantPermissions",
+          origin: page.server_url,
+          permissions: ["clipboardReadWrite"],
+        )
+        click_button("Copy")
+        clip_text = page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")
+        server = Capybara.current_session.server
+        expect(clip_text).to eq(video_url(video, host: server.host, port: server.port))
+      end
+    end
   end
 end

--- a/spec/system_helper.rb
+++ b/spec/system_helper.rb
@@ -16,10 +16,18 @@ RSpec.configure do |config|
       test-type
       headless
     ]
+
+    options_obj = Selenium::WebDriver::Chrome::Options.new(args: options)
+    options_obj.add_preference(
+      "profile.content_settings.exceptions.clipboard",
+      {
+        '*': {'setting': 1},
+      },
+    )
     Capybara::Selenium::Driver.new(
       app,
       browser: :chrome,
-      options: Selenium::WebDriver::Chrome::Options.new(args: options),
+      options: options_obj,
     )
   end
 


### PR DESCRIPTION
[VEUE-192] fixes: copy button disappears when you start the Broadcast; implements: small visual interaction upon click to let the user know the copy was successful
switches to a button style and adds spec coverage for copy-to-clipboard
fixing rubocop issues
[VEUE-192] abstracts copyToClipboard into helper method; changes css to use class-based styling for button (.copy-to-clipboard)