### PR TITLE
VEUE-247 - Make the Chat Message Box Look Like The Design

### DIFF
--- a/app/javascript/style/chat.scss
+++ b/app/javascript/style/chat.scss
@@ -11,6 +11,7 @@
   display: flex;
   flex-direction: column;
   background-color: color.$white;
+  border-radius: 1rem;
   .messages-overflow-container {
     flex: 1 1 auto;
     overflow-y: auto;
@@ -33,9 +34,9 @@
         width: 100%;
 
         &__text {
-          border: 2px solid color.$gray-light-blue;
+          border: 2px solid color.$neutral-accents;
           color: color.$gray-bluish;
-          border-radius: 1rem 1rem 0.5rem 1rem;
+          border-radius: 0px 10px 10px 10px;
         }
       }
 
@@ -105,17 +106,29 @@
   .message-write {
     border-top: 1px solid color.$gray-light-1;
     width: 100%;
-    height: 6rem;
+    height: 4.5rem;
+    border-radius: 1rem;
     .write-area {
-      margin-top: 1rem;
-      padding: 0rem 0.5rem;
+      margin: 1rem;
+      border-radius: 1rem;
+      height: 2.5rem;
+      background: color.$neutral-background;
       &__text {
-        font-size: 1rem;
-        border: none;
+        font-size: 1rem;  
+        border-radius: 0.5rem;
         color: color.$light-black;
-        font-family: font.$poppins;
-        font-weight: 400;
+        font-weight: font.$normal-weight;
+        font-family: font.$nunito;
         resize: none;
+        border: none;
+        background: color.$neutral-background;
+        min-height: 1.8rem;
+        max-height: 50vh;
+        // height: 1.8rem;
+        // height: auto;
+        vertical-align: 1rem;
+        padding-top: 0.6rem;
+         box-sizing: padding-box;
       }
     }
   }

--- a/app/views/shared/_chat.html.haml
+++ b/app/views/shared/_chat.html.haml
@@ -4,6 +4,6 @@
   - unless video.finished?
     .message-write{data: { "controller": "chat", "show-when-logged-in": true }}
       .write-area
-        = text_area_tag :body, "", class: 'write-area__text w-full outline-none', name: "message-input", placeholder: 'Write your message...', data: { action: "keydown->chat#chatBoxKeyDown" }
+        = text_area_tag :body, "", class: 'write-area__text w-full outline-none', :contenteditable => "", :role => "textbox", name: "message-input", placeholder: 'Send a message', data: { action: "keydown->chat#chatBoxKeyDown"}
     .message-login-prompt{data: { "show-when-logged-out": true }}
       %button{data: {action: "authentication#showModal"}} Login To Chat


### PR DESCRIPTION
### VEUE - 247 - Make the Chat Message Box Look Like The Design
Make the chat look like this:

<img src="https://user-images.githubusercontent.com/59073973/99863619-a8951a80-2b64-11eb-830d-2ede75dfe36a.png" width="50" height="50">

- [x] All CSS implementations on chat done [colors, background, height, etc]

- [x] Chat needs to expand when you type without having the scroll bar
