### PR TITLE
[VEUE-257] Broadcaster Event Loop Fails

### DIFF
--- a/app/javascript/helpers/broadcast/timecode_manager.ts
+++ b/app/javascript/helpers/broadcast/timecode_manager.ts
@@ -1,5 +1,6 @@
 import { displayTime } from "util/time";
 import Timecode from "util/timecode";
+import { VideoEventProcessor } from "helpers/event/event_processor";
 
 export default class {
   public timecodeMs: number;
@@ -20,6 +21,7 @@ export default class {
     this.tickInterval = setInterval(() => {
       this.timecodeMs = Date.now() - this.startedAt;
       this.drawTimecode();
+      VideoEventProcessor.syncTime(this.timecodeMs);
     }, 10);
   }
 

--- a/spec/support/broadcast_system_helpers.rb
+++ b/spec/support/broadcast_system_helpers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module BroadcastSystemHelpers
+  def navigate_to(url)
+    bar = find("input[data-target='broadcast--browser.addressBar']")
+    bar.set(url)
+    bar.native.send_keys(:return)
+    expect(find("*[data-broadcast--browser-url]")["data-broadcast--browser-url"]).to eq(url)
+  end
+end

--- a/spec/system/broadcast_spec.rb
+++ b/spec/system/broadcast_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require "system_helper"
-require_relative("../support/audience_spec_helpers")
 
 # Note: These tests are trying to test a sequence that doesn't NORMALLY happen just
 # within the rails app. This has to be combined with the real Electron App to get full / perfect results.
 describe "Broadcast View" do
+  include BroadcastSystemHelpers
+
   let(:user) { create(:user) }
   let(:video) { user.videos.active.first }
 
@@ -40,11 +41,8 @@ describe "Broadcast View" do
 
   describe "before live streaming" do
     it "should allow me to change my URL" do
-      bar = find("input[data-target='broadcast--browser.addressBar']")
-      url = "https://1982.com"
-      bar.set(url)
-      bar.native.send_keys(:return)
-      expect(find("*[data-broadcast--browser-url]")["data-broadcast--browser-url"]).to eq(url)
+      navigate_to(url = "https://1982.com")
+
       find("*[data-broadcast-state='ready']")
       click_button("Start Broadcast")
       find("*[data-broadcast-started-at]")
@@ -91,6 +89,9 @@ describe "Broadcast View" do
         second_message_text = "Cowabunga!"
 
         expect(video.chat_messages.count).to eq(1)
+
+        # VEUE-257 - Navigation events can throw off processing after being live
+        navigate_to("https://1982.com")
 
         expect(find(".message-left")).to have_content(first_message.text)
         expect(page).to_not have_content(second_message_text)


### PR DESCRIPTION
If the broadcaster navigates to a URL, then chat stops working.

This is due to the fact we didn’t actually call `syncTime()` during  the broadcast, so the fact the navigation events had a timecode above 0 meant we never popped them off the stack, and any incoming chat messages with 0 were “stuck behind” higher timecoded items (the BrowserNavigations).

Here, there is a failling test case, and the fix is to call `timeSync` during our timecode loops