### PR TITLE
Veue 241: Add broadcast going live text message feature

### DIFF
--- a/app/controllers/broadcasts_controller.rb
+++ b/app/controllers/broadcasts_controller.rb
@@ -28,6 +28,8 @@ class BroadcastsController < ApplicationController
       },
     )
     current_broadcast_video.start!
+
+    send_broadcast_start_text!
   end
 
   def navigation_update
@@ -58,4 +60,11 @@ class BroadcastsController < ApplicationController
     @current_broadcast_video ||= current_user.videos.find(params[:id])
   end
   helper_method :current_broadcast_video
+
+  def send_broadcast_start_text!
+    SendBroadcastStartTextJob.perform_later(
+      streamer: current_user,
+      video_url: video_url(current_broadcast_video),
+    )
+  end
 end

--- a/app/jobs/send_broadcast_start_text_job.rb
+++ b/app/jobs/send_broadcast_start_text_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class SendBroadcastStartTextJob < ApplicationJob
+  queue_as :default
+
+  def perform(streamer:, video_url:, followers: nil, batch_size: 1000)
+    # Create a batch queue if followers arent passed.
+    if followers.nil?
+      SendBroadcastStartTextJob.queue_in_batches(streamer: streamer,
+                                                 video_url: video_url,
+                                                 batch_size: batch_size)
+    else
+      followers.each do |follower|
+        SmsMessage.notify_broadcast_start!(streamer: streamer,
+                                           video_url: video_url,
+                                           follower: follower)
+      end
+    end
+  end
+
+  def self.queue_in_batches(streamer:, video_url:, batch_size:)
+    streamer.followers.find_in_batches(batch_size: batch_size) do |followers|
+      SendBroadcastStartTextJob.perform_later(
+        streamer: streamer,
+        video_url: video_url,
+        followers: followers,
+      )
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,6 +55,10 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = {host: "localhost", port: 3000}
 
+  # Sets a default host for url_helpers, also no idea why this isnt config.*
+  # https://github.com/excid3/noticed/issues/49
+  routes.default_url_options[:host] = 'localhost:3000'
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,4 +107,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  routes.default_url_options[:host] = "veuelive.com"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,4 +48,8 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = {host: "test.localhost", port: 3000}
+
+  # Sets a default host for url_helpers, also no idea why this isnt config.*
+  # https://github.com/excid3/noticed/issues/49
+  routes.default_url_options[:host] = 'localhost:3000'
 end

--- a/spec/jobs/send_broadcast_start_text_job_spec.rb
+++ b/spec/jobs/send_broadcast_start_text_job_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SendBroadcastStartTextJob, type: :job do
+  let(:streamer) { create(:streamer) }
+  let(:follower) { create(:user) }
+  let(:other_follower) { create(:user) }
+  let(:video) { create(:video) }
+
+  include ActiveJob::TestHelper
+
+  before :example do
+    Follow.create!(streamer_follow: follower, user_follow: streamer)
+    Follow.create!(streamer_follow: other_follower, user_follow: streamer)
+  end
+
+  it "should run without error" do
+    args = {
+      video_url: video_url(video),
+      streamer: streamer,
+    }
+
+    SendBroadcastStartTextJob.perform_later(args)
+    expect(SendBroadcastStartTextJob).to have_been_enqueued.exactly(:once).with(args)
+  end
+
+  it "should run in batches" do
+    args = {
+      video_url: video_url(video),
+      streamer: streamer,
+      batch_size: 1,
+    }
+
+    # Performing now causes 2 jobs to be queued in the background
+    SendBroadcastStartTextJob.perform_now(args)
+    expect(SendBroadcastStartTextJob).to have_been_enqueued.exactly(:twice)
+  end
+
+  it "should send a message to Twilio" do
+    args = {
+      video_url: video_url(video),
+      streamer: streamer,
+    }
+
+    SendBroadcastStartTextJob.perform_now(args)
+    perform_enqueued_jobs(only: SendBroadcastStartTextJob)
+    expect(FakeTwilio.messages.size).to eq(2)
+
+    phone_numbers = streamer.followers.pluck(:phone_number)
+
+    message = FakeTwilio.messages.first
+    # Should contain a full url
+    expect(message.body).to match(/http/)
+
+    expect(message.body).to match(video_url(video))
+
+    expect(phone_numbers).to include(message.to)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,8 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 
 RSpec.configure do |config|
+  # Allows you to do things like *_url(<model>)
+  config.include Rails.application.routes.url_helpers
   config.include AuthenticationTestHelpers::RequestHelpers, type: :request
   config.include WebhookHelpers
   config.include PhoneTestHelpers

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -10,6 +10,7 @@ RSpec.configure do |config|
     Sidekiq::Testing.fake!
   end
   config.before(:each) do
+    clear_enqueued_jobs
     Sidekiq::Worker.clear_all
   end
 end


### PR DESCRIPTION
Broadcast to followers when a streamer has gone live!

- [x] Batch operations (currently uses the default 1000, but this could be tweaked if we notice issues)
- [x] Sends to all followers
- [x] Capybara, ActiveJob, and Model tests in place
- [x] Refactoring of SMS Message
- [x] Add url_helpers for RSpec tests
- [x] Add default_url options to make sure users are sent full urls.


Potential future issues:

- I did not add in any retry functionality here. Perhaps we may want to check the last time a follower was notified about a streamer going live so we dont spam people if someone clicks start and stop multiple times
- No accounting for private / protected broadcasts
- No accounting for if a user has text notifications turned off