### PR TITLE
[VEUE-296] fix: double broadcasting bug

### DIFF
--- a/app/javascript/controllers/broadcast_controller.ts
+++ b/app/javascript/controllers/broadcast_controller.ts
@@ -36,7 +36,7 @@ export default class extends Controller {
   connect(): void {
     const currentVideoState = this.data.get("video-state");
 
-    if (["live", "finished"].includes(currentVideoState)) {
+    if (["starting", "live", "finished"].includes(currentVideoState)) {
       document.location.href = "/broadcasts";
     }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,9 @@ class User < ApplicationRecord
   end
 
   def active_video!
-    return active_video if active_video && !active_video.live?
+    # We need to treat both "live" and "starting" videos as active videos.
+    # Only "pending"  videos should be broadcastable
+    return active_video if active_video&.pending?
 
     active_video&.end!
     create_new_broadcast!

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -61,11 +61,11 @@ class Video < ApplicationRecord
       end
 
       transitions from: :pending, to: :live
-      transitions from: :starting, to: :live
     end
 
     event :end do
       transitions from: :live, to: :ended
+      transitions from: :starting, to: :ended
     end
 
     event :finish do
@@ -73,7 +73,7 @@ class Video < ApplicationRecord
         send_ifttt! "#{user.display_name} stopped streaming"
       end
 
-      transitions from: %i[live paused pending ended], to: :finished
+      transitions from: %i[live paused pending ended starting], to: :finished
     end
   end
 

--- a/spec/system/broadcast_spec.rb
+++ b/spec/system/broadcast_spec.rb
@@ -102,6 +102,16 @@ describe "Broadcast View" do
 
       expect(message1.body).to match(current_video_url)
     end
+
+    it "should not be able to start a broadcast with a 'starting' state on your video" do
+      video.update!(state: "starting")
+      previous_path = page.current_path
+
+      # Should just redirect us to a new broadcast like if it was "live""
+      page.refresh
+
+      expect(page.current_path).to_not eq(previous_path)
+    end
   end
 
   describe "while live streaming" do
@@ -233,8 +243,6 @@ describe "Broadcast View" do
         using_wait_time(5) do
           expect(page).to have_field("title", with: "")
         end
-
-        expect(video.title).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
- [x] - Redirects users if theyre in the `starting` state to prevent double broadcasting

- [x] - Adds state management from `starting` to `finished` / `ending`

- [x] - Only allows pending videos to be started