### PR TITLE
[VEUE-357] Mux Stream Key Missing

### DIFF
--- a/app/controllers/broadcasts_controller.rb
+++ b/app/controllers/broadcasts_controller.rb
@@ -55,9 +55,14 @@ class BroadcastsController < ApplicationController
   private
 
   def current_broadcast_video
-    @current_broadcast_video ||= current_user.channels.first.videos.find(params[:id]).decorate
+    @current_broadcast_video ||= current_channel.videos.find(params[:id]).decorate
   end
   helper_method :current_broadcast_video
+
+  def current_channel
+    @current_channel ||= current_user.channels.first
+  end
+  helper_method :current_channel
 
   def send_broadcast_start_text!
     SendBroadcastStartTextJob.perform_later(

--- a/app/views/broadcasts/show.html.haml
+++ b/app/views/broadcasts/show.html.haml
@@ -3,7 +3,7 @@
     {
       controller: "broadcast broadcast--debug",
       broadcast: {
-        "stream-key": current_user.mux_stream_key,
+        "stream-key": current_channel.mux_stream_key,
         "video-state": current_broadcast_video.state,
         "session-token": current_session_token.uuid
       },

--- a/spec/factories/channels.rb
+++ b/spec/factories/channels.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :channel do
-    user { create(:streamer) }
+    user { create(:user) }
     name { user.display_name }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,8 +8,7 @@ FactoryBot.define do
     phone_number { PhoneTestHelpers.generate_valid }
 
     factory :streamer do
-      mux_stream_key { Faker::Alphanumeric.alphanumeric }
-      mux_live_stream_id { Faker::Alphanumeric.alphanumeric }
+      after(:create, &:setup_as_streamer!)
     end
 
     factory :viewer do

--- a/spec/requests/broadcasts_controller_spec.rb
+++ b/spec/requests/broadcasts_controller_spec.rb
@@ -13,8 +13,9 @@ describe BroadcastsController do
       get broadcasts_path
       follow_redirect!
 
-      expect(@streamer.mux_stream_key).to have_attributes(size: (be > 2))
-      expect(response.body).to include(@streamer.mux_stream_key)
+      stream_key = @streamer.channels.first.mux_stream_key
+      expect(stream_key).to have_attributes(size: (be > 2))
+      expect(response.body).to include(stream_key)
     end
   end
 


### PR DESCRIPTION
If you start a new channel, then the stream key might be missing!

This is because we have shifted the stream_key from the User model to the Channel and while pre-migration users can have a stream key on both their Channel and User, for new users, it’s only on the Channel.

This would break for everyone when we remove the mux_stream_key from the User model.