### PR TITLE
[VEUE-355] LogDNA Branch to Solve Production Issue

### DIFF
--- a/.idea/veue.iml
+++ b/.idea/veue.iml
@@ -131,7 +131,7 @@
     <orderEntry type="library" scope="PROVIDED" name="kaminari-core (v1.2.1, RVM: ruby-2.7.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="listen (v3.2.1, RVM: ruby-2.7.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="lockbox (v0.4.8, RVM: ruby-2.7.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="logdna (v1.4.2, RVM: ruby-2.7.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="logdna (v1.4.2@367fff, RVM: ruby-2.7.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="loofah (v2.7.0, RVM: ruby-2.7.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="mail (v2.7.1, RVM: ruby-2.7.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="marcel (v0.3.3, RVM: ruby-2.7.2) [gem]" level="application" />

--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,8 @@ gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw]
 
 group :production do
   # Gem for sending production logs to LogDNA
-  gem "logdna"
+  # TEMPORARY due to https://github.com/logdna/ruby/issues/30
+  gem "logdna", github: "logdna/ruby", branch: "fixThread"
 
   # Our APM and alerting provider
   gem "appsignal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,16 @@ GIT
   specs:
     ffi (1.13.1)
 
+GIT
+  remote: https://github.com/logdna/ruby.git
+  revision: 367fff3fec9275bb11c9245026d3bbc14b2b3060
+  branch: fixThread
+  specs:
+    logdna (1.4.2)
+      concurrent-ruby (~> 1.0)
+      json (~> 2.0)
+      require_all (~> 1.4)
+
 GEM
   remote: https://rubygems.org/
   remote: https://gems.contribsys.com/
@@ -217,10 +227,6 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     lockbox (0.4.8)
-    logdna (1.4.2)
-      concurrent-ruby (~> 1.0)
-      json (~> 2.0)
-      require_all (~> 1.4)
     loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -449,7 +455,7 @@ DEPENDENCIES
   inline_svg
   listen (~> 3.2)
   lockbox
-  logdna
+  logdna!
   mux_ruby
   pg (>= 0.18, < 2.0)
   phone


### PR DESCRIPTION
In production right now, LogDNA is sending an update on EVERY REQUEST during EVERY TEMPLATE RENDER and it’s massively slowing down the system.

Verified this on stage, moving to prod and carefully monitoring.