### PR TITLE
[VEUE-367]: Add deploy markers based on git commit hash

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -2,3 +2,7 @@ production:
   ignore_errors:
     - ActionController::RoutingError
     - ActiveRecord::RecordNotFound
+
+  # https://render.com/docs/environment-variables
+  # https://docs.appsignal.com/guides/deploy-markers.html#ruby
+  revision: "<%= ENV.fetch('RENDER_GIT_COMMIT', `git log --pretty=format:'%h' -n 1`) %>"


### PR DESCRIPTION
- Uses the `RENDER_COMMIT_HASH` and falls back to a CLI git command for SHA versions.