### PR TITLE
chore(release): 0.1.5

### DIFF
--- a/broadcaster/CHANGELOG.md
+++ b/broadcaster/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 0.1.5 (2021-01-04)
+
+### Features
+
+- add ability to update title of a stream in progress ([80c65ca](https://github.com/veuelive/veue/commit/80c65caa9a4cb65eb0803e6bc96e8ddb18595030))
+- add in active_job helpers ([03fbfcb](https://github.com/veuelive/veue/commit/03fbfcbb6b303ba3bd3cf0f3af7dd3d35eb7c1d7))
+- add in replace state for ?t ([1a025a0](https://github.com/veuelive/veue/commit/1a025a01faba87d2c6ca5c32735ac3ebff1cef86))
+- add uniqueness validator on video views ([08d9491](https://github.com/veuelive/veue/commit/08d9491b9a88650c132af0e498622f236198a459))
+- add validation for title length ([ea82f57](https://github.com/veuelive/veue/commit/ea82f57e434620d9d78584e10f6696e7a40c75b8))
+
+### Bug Fixes
+
+- add a wait_until to allow the model to update ([aa8c7a9](https://github.com/veuelive/veue/commit/aa8c7a9ed14a0bda923c8875e97b6c31e69cd8aa))
+- add type: :job to IFTTTJob ([2c97c92](https://github.com/veuelive/veue/commit/2c97c92ab0d6f7291bf88f5512fcb61a82f1ddc4))
+- broken VOD controls ([f31003e](https://github.com/veuelive/veue/commit/f31003e321d0d26450085e3359f3c0690ac840ee))
+- chopping of data hashes in haml ([67a8cf8](https://github.com/veuelive/veue/commit/67a8cf8d164fe28edbc9a66f0b428db27cfa6f70))
+- double broadcasting error ([ded295e](https://github.com/veuelive/veue/commit/ded295e9ce8ee97475c039ff5e42fad2f2112fc1))
+- make the view counter not raise an error on validation issue ([57d0203](https://github.com/veuelive/veue/commit/57d02034fbe52a465c7b4dd533c0025e9d83d796))
+- minor tweak ([b25debd](https://github.com/veuelive/veue/commit/b25debddc0e3b076fcffd9aa343b29fda9bdb5c0))
+- remove the 4 boxed input, return to a singular input ([a3a1d4e](https://github.com/veuelive/veue/commit/a3a1d4e3325146691887987e31006c6b13672188))
+- sending 'undefined' keys to the server ([d5e4385](https://github.com/veuelive/veue/commit/d5e43859ffcefd6eca9a4a6a966f59f27fd4982a))

--- a/broadcaster/package.json
+++ b/broadcaster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deskie",
   "productName": "Veue-Broadcaster",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "My praiseworthy app",
   "license": "MIT",
   "repository": "veuelive/veue",
@@ -18,7 +18,7 @@
     "start": "yarn build && ENVIRONMENT=localhost electron .",
     "pack": "yarn build && electron-builder --dir",
     "dist": "yarn build && electron-builder --macos",
-    "release": "yarn build && electron-builder --macos --publish always"
+    "release": "yarn build && electron-builder -mw --publish always"
   },
   "dependencies": {
     "@logdna/logger": "^2.1.0",


### PR DESCRIPTION
This PR is bumping Broadcaster app version from 0.1.4 to 0.1.5.