### PR TITLE
[VEUE-372]: Add support for private streams

### DIFF
--- a/app/controllers/broadcasts_controller.rb
+++ b/app/controllers/broadcasts_controller.rb
@@ -30,8 +30,6 @@ class BroadcastsController < ApplicationController
         :url,
       ),
     )
-
-    send_broadcast_start_text!
   end
 
   def navigation_update
@@ -67,13 +65,6 @@ class BroadcastsController < ApplicationController
     @current_channel ||= current_user.channels.first
   end
   helper_method :current_channel
-
-  def send_broadcast_start_text!
-    SendBroadcastStartTextJob.perform_later(
-      channel: current_broadcast_video.channel,
-      channel_url: channel_url(current_broadcast_video.channel),
-    )
-  end
 
   def video_params
     params.require(:video).permit(:title, :visibility)

--- a/app/javascript/controllers/broadcast/settings_controller.ts
+++ b/app/javascript/controllers/broadcast/settings_controller.ts
@@ -1,9 +1,11 @@
 import { Controller } from "stimulus";
+import { Visibility, setVideoVisibility } from "../../helpers/video_helpers";
 
 export default class SettingsController extends Controller {
-  static targets = ["form"];
+  static targets = ["form", "visibility"];
 
   private readonly formTarget!: HTMLFormElement;
+  private readonly visibilityTarget!: HTMLSelectElement;
 
   connect(): void {
     this.toggleForm();
@@ -22,6 +24,9 @@ export default class SettingsController extends Controller {
 
   handleAjaxSuccess(): void {
     this.handleAjax("success");
+
+    const visibility = this.visibilityTarget.value as Visibility;
+    setVideoVisibility(visibility);
   }
 
   handleAjaxError(): void {

--- a/app/javascript/controllers/broadcast/share_controller.ts
+++ b/app/javascript/controllers/broadcast/share_controller.ts
@@ -3,7 +3,9 @@ import {
   copyToClipboard,
   openLinkInBrowser,
   publicVideoLink,
+  privateVideoLink,
 } from "helpers/broadcast_helpers";
+import { getVideoVisibility } from "helpers/video_helpers";
 
 export default class extends Controller {
   static targets = ["menu"];
@@ -25,14 +27,23 @@ export default class extends Controller {
   openLink(event: Event): void {
     this.hide();
     event.stopPropagation();
-    openLinkInBrowser(publicVideoLink());
+
+    openLinkInBrowser(this.getVideoLink());
   }
 
   copyLink(event: Event): void {
     this.hide();
     event.stopPropagation();
-    copyToClipboard(publicVideoLink());
-    alert("Public Link Copied to Clipboard!");
+    copyToClipboard(this.getVideoLink());
+    alert("Link Copied to Clipboard!");
+  }
+
+  private getVideoLink(): string {
+    if (getVideoVisibility() === "private") {
+      return privateVideoLink();
+    }
+
+    return publicVideoLink();
   }
 
   private hide() {

--- a/app/javascript/helpers/broadcast_helpers.ts
+++ b/app/javascript/helpers/broadcast_helpers.ts
@@ -2,8 +2,9 @@ import { Rectangle, Size } from "types/rectangle";
 import { postJson } from "util/fetch";
 import { NavigationUpdate } from "controllers/broadcast/browser_controller";
 import { electron, inElectronApp } from "helpers/electron/base";
-import { getChannelSlug } from "helpers/channel_helpers";
 import VideoLayout from "types/video_layout";
+import { getChannelSlug, getChannelId } from "helpers/channel_helpers";
+import { getVideoId } from "helpers/video_helpers";
 
 export function getBroadcastElement(): HTMLElement {
   return document.getElementById("broadcast");
@@ -31,6 +32,12 @@ export function openLinkInBrowser(url: string): void {
 
 export function publicVideoLink(): string {
   return document.location.origin + "/" + getChannelSlug();
+}
+
+export function privateVideoLink(): string {
+  return (
+    document.location.origin + "/" + getChannelId() + "/videos/" + getVideoId()
+  );
 }
 
 export function calculateCaptureLayout(

--- a/app/javascript/helpers/video_helpers.ts
+++ b/app/javascript/helpers/video_helpers.ts
@@ -1,0 +1,32 @@
+export function getVideoId(): string {
+  return document
+    .querySelector("*[data-video-id]")
+    .getAttribute("data-video-id");
+}
+
+export type Visibility = "public" | "private" | "protected" | null;
+const VISIBILITIES = ["public", "private", "protected"];
+
+export function setVideoVisibility(visibility: Visibility): void {
+  if (!VISIBILITIES.includes(visibility)) {
+    return;
+  }
+
+  getVideoVisibilityElement().setAttribute("data-video-visibility", visibility);
+}
+
+export function getVideoVisibility(): Visibility {
+  const visibility = getVideoVisibilityElement().getAttribute(
+    "data-video-visibility"
+  ) as Visibility;
+
+  if (VISIBILITIES.includes(visibility)) {
+    return visibility;
+  }
+
+  return null;
+}
+
+function getVideoVisibilityElement(): HTMLElement {
+  return document.querySelector("*[data-video-visibility]");
+}

--- a/app/jobs/send_broadcast_start_text_job.rb
+++ b/app/jobs/send_broadcast_start_text_job.rb
@@ -3,32 +3,23 @@
 class SendBroadcastStartTextJob < ApplicationJob
   queue_as :default
 
-  def perform(channel:, channel_url:, followers: nil, batch_size: 1000)
+  def perform(channel, followers: nil, batch_size: 1000)
     # Create a batch queue if followers arent passed.
     if followers.nil?
-      SendBroadcastStartTextJob.queue_in_batches(
-        channel: channel,
-        channel_url: channel_url,
-        batch_size: batch_size,
-      )
-    else
-      followers.each do |follower|
-        SmsMessage.notify_broadcast_start!(
-          channel: channel,
-          channel_url: channel_url,
-          follower: follower,
-        )
-      end
+      queue_in_batches(channel, batch_size: batch_size)
+      return
+    end
+
+    followers.each do |follower|
+      SmsMessage.notify_broadcast_start!(channel: channel, follower: follower)
     end
   end
 
-  def self.queue_in_batches(channel:, channel_url:, batch_size:)
+  private
+
+  def queue_in_batches(channel, batch_size:)
     channel.followers.find_in_batches(batch_size: batch_size) do |followers|
-      SendBroadcastStartTextJob.perform_later(
-        channel: channel,
-        channel_url: channel_url,
-        followers: followers,
-      )
+      SendBroadcastStartTextJob.perform_later(channel, followers: followers)
     end
   end
 end

--- a/app/lib/router.rb
+++ b/app/lib/router.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# A top-level namespace for using Rails URL helpers.
+# @example
+#   Router.root_path
+#   Router.user_path(user)
+#
+# @see https://www.dwightwatson.com/posts/accessing-rails-routes-helpers-from-anywhere-in-your-app
+module Router
+  class << self
+    include Rails.application.routes.url_helpers
+  end
+
+  def self.default_mailer_url_options
+    Rails.application.config.action_mailer.default_url_options
+  end
+
+  def self.default_url_options
+    Rails.application.routes.default_url_options
+  end
+end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -156,11 +156,19 @@ class Video < ApplicationRecord
 
   def after_go_live
     transition_audience_to_live
+
+    return if visibility.eql?("private")
+
     send_ifttt!("#{user.display_name} went live!")
+    send_broadcast_start_text!
   end
 
   def send_ifttt!(message)
-    url = "https://www.veuelive.com/videos/#{id}"
+    url = Router.channel_video_url(channel, self)
     IfThisThenThatJob.perform_later(message: message, url: url)
+  end
+
+  def send_broadcast_start_text!
+    SendBroadcastStartTextJob.perform_later(channel)
   end
 end

--- a/app/views/broadcasts/show.html.haml
+++ b/app/views/broadcasts/show.html.haml
@@ -8,6 +8,7 @@
         "session-token": current_session_token.uuid
       },
       "video-id": current_broadcast_video.id,
+      "video-visibility": current_broadcast_video.visibility,
       "channel-id": current_broadcast_video.channel.id,
       "channel-slug": current_broadcast_video.channel.slug
     }

--- a/app/views/channels/videos/partials/_edit.html.haml
+++ b/app/views/channels/videos/partials/_edit.html.haml
@@ -7,6 +7,6 @@
   = form.text_field :title, placeholder: "Title your broadcast!"
 
   = form.label :visibility
-  = form.select :visibility, Video.visibilities
+  = form.select :visibility, Video.visibilities, {}, data: { target: "broadcast--settings.visibility" }
 
   = form.submit "Update", class: "btn"

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,6 @@ module Veue
     # Following the advice on https://github.com/mperham/sidekiq/wiki/Active-Job
     config.action_mailer.deliver_later_queue_name = nil # defaults to "mailers"
     config.active_storage.queues.analysis   = nil       # defaults to "active_storage_analysis"
-    config.active_storage.queues.purge      = nil      
+    config.active_storage.queues.purge      = nil
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,9 +57,10 @@ Rails.application.configure do
 
   # Sets a default host for url_helpers, also no idea why this isnt config.*
   # https://github.com/excid3/noticed/issues/49
-  routes.default_url_options[:host] = 'localhost:3000'
+  default_url_options[:host] = ENV.fetch("HOSTNAME", "localhost:3000")
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end
+

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,5 +51,6 @@ Rails.application.configure do
 
   # Sets a default host for url_helpers, also no idea why this isnt config.*
   # https://github.com/excid3/noticed/issues/49
-  routes.default_url_options[:host] = 'localhost:3000'
+  routes.default_url_options[:host] = 'test.localhost'
+  routes.default_url_options[:port] = 3000
 end

--- a/spec/factories/follows.rb
+++ b/spec/factories/follows.rb
@@ -2,8 +2,6 @@
 
 FactoryBot.define do
   factory :follow do
-    follower_user_id { user.to_param }
-    streamer_user_id { user.to_param }
     unfollowed_at { nil }
   end
 end

--- a/spec/jobs/send_broadcast_start_text_job_spec.rb
+++ b/spec/jobs/send_broadcast_start_text_job_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe SendBroadcastStartTextJob, type: :job do
   let(:channel) { create(:channel) }
   let(:follower) { create(:user) }
   let(:other_follower) { create(:user) }
-  let(:video) { create(:video) }
 
   include ActiveJob::TestHelper
 
@@ -15,46 +14,41 @@ RSpec.describe SendBroadcastStartTextJob, type: :job do
     Follow.create!(user: other_follower, channel: channel)
   end
 
-  it "should run without error" do
-    args = {
-      channel_url: channel_url(video.channel),
-      channel: channel,
-    }
+  describe "Live public videos" do
+    # Cannot be lazy loaded!
+    let!(:active_video) { create(:live_video, channel: channel) }
 
-    SendBroadcastStartTextJob.perform_later(args)
-    expect(SendBroadcastStartTextJob).to have_been_enqueued.exactly(:once).with(args)
-  end
+    it "should run without error" do
+      SendBroadcastStartTextJob.perform_later(channel)
+      expect(SendBroadcastStartTextJob).to have_been_enqueued.exactly(:once).with(channel)
 
-  it "should run in batches" do
-    args = {
-      channel_url: channel_url(video.channel),
-      channel: channel,
-      batch_size: 1,
-    }
+      # A second job is queued, the first one is just a batch
+      perform_enqueued_jobs(only: SendBroadcastStartTextJob)
+      expect(SendBroadcastStartTextJob).to have_been_enqueued.exactly(:once).with(channel)
+    end
 
-    # Performing now causes 2 jobs to be queued in the background
-    SendBroadcastStartTextJob.perform_now(args)
-    expect(SendBroadcastStartTextJob).to have_been_enqueued.exactly(:twice)
-  end
+    it "should run in batches based on batch_size" do
+      # Performing now causes 2 jobs to be queued in the background
+      # We do perform_now because it will queue 2 "perform_later" in the background
+      SendBroadcastStartTextJob.perform_now(channel, batch_size: 1)
+      expect(SendBroadcastStartTextJob).to have_been_enqueued.exactly(:twice)
+    end
 
-  it "should send a message to Twilio" do
-    args = {
-      channel_url: channel_url(video.channel),
-      channel: channel,
-    }
+    it "should send a message to Twilio" do
+      SendBroadcastStartTextJob.perform_now(channel)
+      perform_enqueued_jobs(only: SendBroadcastStartTextJob)
+      expect(FakeTwilio.messages.size).to eq(2)
 
-    SendBroadcastStartTextJob.perform_now(args)
-    perform_enqueued_jobs(only: SendBroadcastStartTextJob)
-    expect(FakeTwilio.messages.size).to eq(2)
+      phone_numbers = channel.followers.pluck(:phone_number)
 
-    phone_numbers = channel.followers.pluck(:phone_number)
+      message = FakeTwilio.messages.first
+      # Should contain a full url
+      expect(message.body).to match(%r{http://test.localhost})
 
-    message = FakeTwilio.messages.first
-    # Should contain a full url
-    expect(message.body).to match(/http/)
+      expect(message.body).to match(channel.slug)
+      expect(message.body).to match(channel.active_video.id)
 
-    expect(message.body).to match(channel_url(video.channel))
-
-    expect(phone_numbers).to include(message.to)
+      expect(phone_numbers).to include(message.to)
+    end
   end
 end

--- a/spec/models/sms_message_spec.rb
+++ b/spec/models/sms_message_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe SmsMessage, type: :model do
-  let(:channel) { create(:channel) }
-  let(:follower) { create(:user) }
-  let(:video) { create(:video) }
+  let(:streamer) { create(:streamer) }
+  let(:channel) { streamer.channels.first }
+  let(:follower) { create(:follow, user: create(:user), channel: channel).user }
 
   describe ".build_text" do
     it "should generate a message with the code" do
@@ -37,15 +37,13 @@ RSpec.describe SmsMessage, type: :model do
   end
 
   describe ".notify_broadcast_start!" do
-    it "should try and message twillio" do
-      Follow.create!(user: follower, channel: channel)
+    let!(:video) { create(:video, channel: channel, user: streamer) }
 
+    it "should try and message twillio" do
       SmsMessage.notify_broadcast_start!(
         channel: channel,
         follower: follower,
-        channel_url: channel_url(channel),
       )
-
       expect(FakeTwilio.messages.size).to eq(1)
 
       message = FakeTwilio.messages.first

--- a/spec/system/broadcast/commands_spec.rb
+++ b/spec/system/broadcast/commands_spec.rb
@@ -25,6 +25,11 @@ describe "Broadcast Commands" do
     channel_url(channel, host: server.host, port: server.port)
   end
 
+  def private_share_link
+    server = Capybara.current_session.server
+    channel_video_url(channel.id, channel.active_video, host: server.host, port: server.port)
+  end
+
   describe "share features" do
     it "can copy the stream URL to the clipboard while streaming" do
       page.driver.browser.execute_cdp(
@@ -52,6 +57,47 @@ describe "Broadcast Commands" do
         end
       switch_to_window audience_window
       expect(current_url).to eq(channel_share_link)
+    end
+
+    describe "Change urls when private" do
+      before do
+        find("#settings-btn").click
+        within(".broadcast-settings__form") do
+          select("private", from: "video_visibility")
+          click_button("Update")
+        end
+        expect(page).to have_css("[data-video-visibility='private']")
+      end
+
+      it "should copy the private link" do
+        page.driver.browser.execute_cdp(
+          "Browser.grantPermissions",
+          origin: page.server_url,
+          permissions: ["clipboardReadWrite"],
+        )
+        find(".btn#share-btn").hover
+        expect(page).to have_content("Share")
+        find(".btn#share-btn").click
+        expect(find(".btn#share-btn .select-menu")).to have_content("Copy")
+        find(".item.copy").click
+        accept_alert
+        clip_text = page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")
+
+        expect(clip_text).to eq(private_share_link)
+        expect(clip_text).to include(channel.id)
+        expect(clip_text).to include(channel.active_video.id)
+      end
+
+      it "should open the private link" do
+        find(".btn#share-btn").click
+        expect(find(".btn#share-btn .select-menu")).to have_content("Copy")
+        audience_window =
+          window_opened_by do
+            find(".item.open").click
+          end
+        switch_to_window audience_window
+        expect(current_url).to eq(private_share_link)
+      end
     end
   end
 end


### PR DESCRIPTION
- Adds support for private streams
- Private stream urls now look like: `http://veuelive.com/:channel_uuid/videos/:video_uuid`
- open / copy link use the above format instead of the channel slug
- SendBroadcastStartTextJob refactored to only need to be passed a channel.