### PR TITLE
[VEUE-384]: fix padding and display of player controls

### DIFF
--- a/app/javascript/style/video/_player_controls.scss
+++ b/app/javascript/style/video/_player_controls.scss
@@ -64,7 +64,7 @@
 
   .player-controls {
     opacity: 0;
-    padding: 0.5rem 0.75rem;
+    padding: 0.5rem;
     color: white;
     transition: 100ms opacity;
     border-radius: 1rem;
@@ -75,6 +75,7 @@
     display: flex;
     transform: translate(-50%, -50%);
     align-items: center;
+    z-index: 2;
 
     .time-display {
       display: none;
@@ -150,12 +151,19 @@
     .toggle-play.desktop {
       display: none;
     }
+
+    .player-controls {
+      display: none;
+    }
+
+    @include vod {
+      .player-controls {
+        display: flex;
+      }
+    }
   }
 
   @include vod {
-    .display-time {
-    }
-
     .progress-bar-container {
       display: flex;
     }


### PR DESCRIPTION
/26425882/103688048-40a56280-4f5f-11eb-8d69-eecbe7f1d10c.png">
- Fix an issue brought up by @agustin-zapata about padding of player-controls
- Fix an issue with player-controls displaying on mobile live videos
- VOD Scrubber now has a > z-index than PIP.

## Z-index fix

<img width="592" alt="Screen Shot 2021-01-05 at 1 26 31 PM" src="https://user-images.githubusercontent.com/26425882/103684648-e655d300-4f59-11eb-8794-5c3cb3bbe93a.png">

## Padding fix

<img width="1440" alt="Screen Shot 2021-01-05 at 2 05 55 PM" src="https://user-images.githubusercontent.com

## Black Box Fix

<img width="1440" alt="Screen Shot 2021-01-05 at 2 05 55 PM" src="https://user-images.githubusercontent.com/26425882/103688153-6599d580-4f5f-11eb-90b1-782ce0b9638d.png">

