### PR TITLE
[Veue 385]: Do not broadcast for private / protected

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,4 +151,7 @@ group :test do
 
   # Adding Database Cleaner to make sure our DB is clean when we test
   gem "database_cleaner-active_record"
+
+  # Adds the ability to stub requests easily
+  gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,8 @@ GEM
     childprocess (3.0.0)
     concurrent-ruby (1.1.7)
     connection_pool (2.2.3)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     database_cleaner (1.8.5)
     database_cleaner-active_record (1.8.0)
@@ -186,6 +188,7 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
+    hashdiff (1.0.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -414,6 +417,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
+    webmock (3.11.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (5.2.1)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -476,6 +483,7 @@ DEPENDENCIES
   wdm (>= 0.1.0)
   web-console (>= 3.3.0)
   webdrivers
+  webmock
   webpacker
 
 RUBY VERSION

--- a/app/jobs/if_this_then_that_job.rb
+++ b/app/jobs/if_this_then_that_job.rb
@@ -12,13 +12,16 @@ class IfThisThenThatJob < ApplicationJob
     IfThisThenThatJob.process!(message: message, url: url)
   end
 
+  def self.post_url
+    IFTTT_URL + "/" + ENV["IFTTT_PUSH_KEY"]
+  end
+
   def self.process!(message:, url:)
-    post_url = "#{IFTTT_URL}/#{ENV['IFTTT_PUSH_KEY']}"
     payload = {
       value1: message,
       value2: url,
     }
-    Faraday.post(post_url, payload.to_json, "Content-Type": "application/json") unless Rails.env.test?
+    Faraday.post(post_url, payload.to_json, "Content-Type": "application/json")
     [post_url, payload]
   end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -76,7 +76,7 @@ class Video < ApplicationRecord
 
     event :finish do
       after do
-        send_ifttt! "#{user.display_name} stopped streaming"
+        send_ifttt! "#{user.display_name} stopped streaming" if visibility.eql?("public")
       end
 
       transitions from: %i[live paused pending ended starting], to: :finished
@@ -165,7 +165,7 @@ class Video < ApplicationRecord
   def after_go_live
     transition_audience_to_live
 
-    return if %w[private protected].include?(visibility)
+    return unless visibility.eql?("public")
 
     send_ifttt!("#{user.display_name} went live!")
     send_broadcast_start_text!

--- a/spec/jobs/if_this_then_that_job_spec.rb
+++ b/spec/jobs/if_this_then_that_job_spec.rb
@@ -15,12 +15,18 @@ RSpec.describe IfThisThenThatJob, type: :job do
       message: message,
       url: url,
     )
+
+    perform_enqueued_jobs(only: IfThisThenThatJob)
+
+    expect(WebMock).to have_requested(:post, IfThisThenThatJob.post_url)
+      .with(body: {value1: message, value2: url})
+      .once
   end
 
   it "should build a payload" do
     url = "hello.com"
     result = IfThisThenThatJob.process!(message: "whoops", url: url)
-    expect(result[0]).to include(IfThisThenThatJob::IFTTT_URL)
+    expect(result[0]).to include(IfThisThenThatJob.post_url)
 
     payload_hash = result[1].inspect
     expect(payload_hash).to include(url)

--- a/spec/support/broadcast_system_helpers.rb
+++ b/spec/support/broadcast_system_helpers.rb
@@ -7,4 +7,14 @@ module BroadcastSystemHelpers
     bar.native.send_keys(:return)
     expect(find("*[data-broadcast--browser-url]")["data-broadcast--browser-url"]).to eq(url)
   end
+
+  def update_video_visibility(visibility)
+    find("#settings-btn").click
+    within(".broadcast-settings__form") do
+      find("[value='#{visibility}']").select_option
+      click_button("Update")
+    end
+
+    expect(page).to have_css("[data-video-visibility='#{visibility}']")
+  end
 end

--- a/spec/system/broadcast/commands_spec.rb
+++ b/spec/system/broadcast/commands_spec.rb
@@ -60,18 +60,9 @@ describe "Broadcast Commands" do
     end
 
     describe "Change urls when private or protected" do
-      before do
-        find("#settings-btn").click
-      end
-
       %w[private protected].each do |visibility|
         it "should copy the private / protected link" do
-          within(".broadcast-settings__form") do
-            find("[value='#{visibility}']").select_option
-            click_button("Update")
-          end
-
-          expect(page).to have_css("[data-video-visibility='#{visibility}']")
+          update_video_visibility(visibility)
 
           page.driver.browser.execute_cdp(
             "Browser.grantPermissions",
@@ -92,10 +83,7 @@ describe "Broadcast Commands" do
         end
 
         it "should open the private / protected link" do
-          within(".broadcast-settings__form") do
-            find("[value='#{visibility}']").select_option
-            click_button("Update")
-          end
+          update_video_visibility(visibility)
 
           expect(page).to have_css("[data-video-visibility='#{visibility}']")
 


### PR DESCRIPTION
Yes. Its me again. It appears I missed the `end broadcast` side of things. Heres a whole lot of mock tests around IFTTT to make sure we dont broadcast people who dont want to be broadcasted!!

- Adds Webmock for stubbing
- Remove if Rails.env.test?, lets just stub it !
- Tests around the entire enchilada of a broadcast lifecycle and who we notify