### PR TITLE
[VEUE: 370]: Add support for precompiling assets before testing

### DIFF
--- a/spec/support/precompile_assets.rb
+++ b/spec/support/precompile_assets.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Reference: https://github.com/anycable/anycable_rails_demo/blob/master/spec/system/support/precompile_assets.rb
+# Precompile assets before running tests to avoid timeouts.
+# Do not precompile if webpack-dev-server is running (NOTE: MUST be launched with RAILS_ENV=test)
+RSpec.configure do |config|
+  config.before(:suite) do
+    examples = RSpec.world.filtered_examples.values.flatten
+    has_no_system_tests = examples.none? { |example| example.metadata[:type] == :system }
+
+    if has_no_system_tests
+      $stdout.puts "\n🚀️️  No system test selected. Skip assets compilation.\n"
+      next
+    end
+
+    if Webpacker.dev_server.running?
+      $stdout.puts "\n⚙️  Webpack dev server is running! Skip assets compilation.\n"
+      next
+    else
+      $stdout.puts "\n🐢  Precompiling assets.\n"
+      original_stdout = $stdout.clone
+      # Use test-prof now 'cause it couldn't be monkey-patched (e.g., by Timecop or similar)
+      start = Time.current
+      begin
+        # Silence Webpacker output
+        $stdout.reopen(File.new("/dev/null", "w"))
+        # next 3 lines to compile webpacker before running our test suite
+        require "rake"
+        Rails.application.load_tasks
+        Rake::Task["webpacker:compile"].execute
+      ensure
+        $stdout.reopen(original_stdout)
+        $stdout.puts "Finished in #{(Time.current - start).round(2)} seconds"
+      end
+    end
+  end
+end

--- a/spec/system_helper.rb
+++ b/spec/system_helper.rb
@@ -65,3 +65,5 @@ RSpec.configure do |config|
     end
   end
 end
+
+require File.join(__dir__, "support/precompile_assets.rb")


### PR DESCRIPTION
I had done some perusing on system specs and reading through how others handle capybara test suites. Precompiling our assets could be a big step forward in reducing timeouts on both local and CI tests. Theres a lot of other useful tips and tricks in there, but this seemed like an easy win. For those who dont know if the assets arent precompiled, Rails has to start a thread to compile your assets for each page in a Capybara system test. This should hopefully help reduce timeout errors.

https://evilmartians.com/chronicles/system-of-a-test-setting-up-end-to-end-rails-testing#system-tests-in-a-nutshell

https://github.com/anycable/anycable_rails_demo/blob/master/spec/system/support/precompile_assets.rb