### PR TITLE
[VEUE-419]: Add references for mux_webhooks on channels

### DIFF
--- a/db/migrate/20210108183034_add_reference_to_mux_webhooks_for_channels.rb
+++ b/db/migrate/20210108183034_add_reference_to_mux_webhooks_for_channels.rb
@@ -1,0 +1,5 @@
+class AddReferenceToMuxWebhooksForChannels < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :mux_webhooks, :channel, type: :uuid, index: true
+  end
+end

--- a/db/migrate/20210111135504_enable_uuid_ossp_extension.rb
+++ b/db/migrate/20210111135504_enable_uuid_ossp_extension.rb
@@ -1,0 +1,5 @@
+class EnableUuidOsspExtension < ActiveRecord::Migration[6.0]
+  def change
+    enable_extension 'uuid-ossp'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_06_173803) do
-
-  # These are extensions that must be enabled in order to support this database
+ActiveRecord::Schema.define(version: 2021_01_11_135504) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   # These are custom enum types that must be created before they can be used in the schema definition
   create_enum "sms_status_setting", ["new_number", "instructions_sent", "unsubscribed"]
@@ -76,6 +75,8 @@ ActiveRecord::Schema.define(version: 2021_01_06_173803) do
     t.uuid "user_id"
     t.uuid "video_id"
     t.string "event_type"
+    t.uuid "channel_id"
+    t.index ["channel_id"], name: "index_mux_webhooks_on_channel_id"
     t.index ["mux_id"], name: "index_mux_webhooks_on_mux_id", unique: true
     t.index ["user_id"], name: "index_mux_webhooks_on_user_id"
     t.index ["video_id"], name: "index_mux_webhooks_on_video_id"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,4 +3,11 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
+  # Use streamer since streamers are users with more permissions
+  # An issue was found specific to mux_webhooks not being referenced in our migrations
+  let!(:user) { create(:streamer) }
+
+  it "should allow us to delete users" do
+    expect { user.destroy! }.to change { User.count }.from(1).to(0)
+  end
 end


### PR DESCRIPTION
- Adds references and indexes for mux_webhooks on channels
- Previously, we were receiving an error the mux_webhooks did not exist on channel when we would destroy a user.


Current Error:

```bash
rails c

User.find_by(display_name: "konnor").destroy!

Traceback (most recent call last):
        1: from (irb):1
ActiveRecord::StatementInvalid (PG::UndefinedColumn: ERROR:  column mux_webhooks.channel_id does not exist)
LINE 1: SELECT "mux_webhooks".* FROM "mux_webhooks" WHERE "mux_webho...
```

Looking at our db/schema.rb we dont store a reference to the `channel` that a `mux_webhook` belongs to.

The test included here fails on main, but passes with this change.