### PR TITLE
[Veue 470]: Fix the footer!

### DIFF
--- a/app/javascript/style/_layout.scss
+++ b/app/javascript/style/_layout.scss
@@ -1,11 +1,12 @@
-$header-height: 54px;
+@use "./utils/scale";
+@use "./utils/breakpoints" as *;
 
 #layout-container {
   display: flex;
   flex-direction: column;
 
   #main-container {
-    height: calc(100vh - #{$header-height});
+    min-height: calc(100vh - #{scale.$header_height});
     display: flex;
     justify-content: center;
     padding: 0;
@@ -14,6 +15,14 @@ $header-height: 54px;
       padding-top: 2vh;
       flex: 1;
       display: flex;
+    }
+  }
+
+  @include desktop() {
+    #main-container {
+      min-height: calc(
+        100vh - #{scale.$header_height} - #{scale.$footer_desktop_height}
+      );
     }
   }
 }

--- a/app/javascript/style/channel/_channel_profile.scss
+++ b/app/javascript/style/channel/_channel_profile.scss
@@ -2,16 +2,14 @@
 @use "../utils/font";
 @use "../utils/breakpoints" as *;
 
-$header-height: 54px;
-
-#channel-profile {
+#channels__show #channel-profile {
   width: 100vw;
   position: relative;
   overflow-y: scroll;
   overflow-x: hidden;
-  min-height: calc(100vh - #{$header-height});
   display: flex;
   flex-direction: column;
+  flex: 1;
 
   #channel-profile__background {
     position: absolute;
@@ -26,7 +24,6 @@ $header-height: 54px;
   #channel-profile__area {
     margin: 78px 10px 0 10px;
     font-size: 0.875rem;
-    text-transform: capitalize;
   }
 
   @include desktop() {

--- a/app/javascript/style/components/_footer.scss
+++ b/app/javascript/style/components/_footer.scss
@@ -1,3 +1,4 @@
+@use "../utils/scale";
 @use "../utils/color";
 @use '../utils/breakpoints' as *;
 
@@ -7,9 +8,10 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: 100%;
-  padding: 10px 0;
+  flex: 1;
   margin-top: auto;
+  min-height: scale.$footer_mobile_height;
+  max-height: scale.$footer_mobile_height;
 
   // style
   font-size: 15px;
@@ -44,6 +46,9 @@
 
 @include desktop() {
   .main-footer {
+    padding: 0 10px;
+    min-height: scale.$footer_desktop_height;
+    max-height: scale.$footer_desktop_height;
     flex-direction: row;
     justify-content: space-between;
   }

--- a/app/javascript/style/discover.scss
+++ b/app/javascript/style/discover.scss
@@ -1,16 +1,116 @@
 body#discover__index {
-  .videos {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
+  #main-container {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+
+    .content-area {
+      width: 100vw;
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      align-items: center;
+
+      .discover-area {
+        max-width: 1400px;
+        display: flex;
+        width: calc(100% - 50px);
+        flex-direction: column;
+        margin: 0 auto;
+        align-items: stretch;
+
+        h2 {
+          margin-left: 20px;
+        }
+
+        // Needs to be wrapped so that the overflow can be set
+        .popular-streamers__container {
+          max-width: 1004px;
+          width: 100%;
+          margin-left: 20px;
+
+          .popular-streamers {
+            width: 100%;
+            display: flex;
+            margin: 30px 20px;
+            height: 160px;
+            overflow-x: auto;
+
+            > .streamer-picture {
+              display: inline-block;
+              margin-right: 29px;
+
+              &:last-child {
+                margin-right: 0;
+              }
+            }
+          }
+        }
+
+        .live-broadcasts,
+        .recent-broadcasts {
+          display: grid;
+          justify-content: space-around;
+          grid-template-columns: minmax(0, 1fr);
+          column-gap: 10px;
+          align-items: center;
+        }
+
+        .live-broadcasts {
+          .video-card:nth-child(1n + 2) {
+            display: none;
+          }
+        }
+      }
+
+      .main-footer {
+        align-self: stretch;
+        margin-top: auto;
+      }
+    }
   }
 
-  #main-container {
-    .content-area {
-      flex-direction: column;
-      h2 {
-        text-align: center;
+  @include desktop() {
+    #main-container {
+      .content-area {
+        .discover-area {
+          margin: 0 140px;
+
+          .popular-streamers__container {
+            width: 100%;
+            margin: 0;
+          }
+
+          .live-broadcasts,
+          .recent-broadcasts {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+          }
+
+          .live-broadcasts {
+            // Sets the 2nd video to display: block
+            .video-card:nth-child(2) {
+              display: block;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // When 3 videos appear in the grid
+  @media only screen and (min-width: 1100px) {
+    #main-container .content-area .discover-area {
+      .live-broadcasts,
+      .recent-broadcasts {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+
+      .live-broadcasts {
+        // Shows all videos
+        .video-card:nth-child(1n) {
+          display: block;
+        }
       }
     }
   }

--- a/app/javascript/style/utils/scale.scss
+++ b/app/javascript/style/utils/scale.scss
@@ -1,11 +1,18 @@
-$video_height: 800;
-$video_width: 1280;
-$primary_height: 740px;
-$primary_width: 1200px;
-$secondary_height: 340px;
-$secondary_height: 420px;
-$video_ratio: $video_height / $video_width;
+$header_height: 54px;
+$footer_mobile_height: 105px;
+$footer_desktop_height: 65px;
 
+@mixin aspect-ratio() {
+  // https://css-tricks.com/aspect-ratio-boxes/
+  &:before {
+    content: "";
+    width: 1px;
+    margin-left: -1px;
+    float: left;
+    height: 0;
+    padding-top: 591.44px / 1127.34px * 100%;
+  }
+}
 // Video Cards
 $screenshot_height_scalable: 5vw;
 $screenshot_height_fixed: 150px;

--- a/app/javascript/style/video/_layout.scss
+++ b/app/javascript/style/video/_layout.scss
@@ -1,7 +1,14 @@
 @use "../utils/breakpoints" as *;
+@use "../utils/scale";
 
 #videos__show,
 #channels__show {
+  #main-container {
+    height: calc(100vh - #{scale.$header_height});
+
+    // reset min-height
+    min-height: auto;
+  }
   overflow-x: hidden;
 
   #streamer-profile-area {
@@ -10,6 +17,10 @@
 
   .broadcasts__header {
     margin-bottom: 0;
+  }
+
+  .content-area__secondary {
+    margin-top: 10px;
   }
 
   /**
@@ -55,6 +66,10 @@
 
       .broadcasts {
         display: grid;
+      }
+
+      .main-footer {
+        display: flex;
       }
     }
   }
@@ -226,14 +241,13 @@
   }
 }
 
+/* This allows us to disable the broadcasts and footers for mobile while videos
+   are playing */
 [data-audience-view-stream-type="vod"],
 [data-audience-view-stream-type="upcoming"],
 [data-audience-view-stream-type="live"] {
+  .main-footer,
   .broadcasts {
     display: none;
-  }
-
-  .content-area__secondary {
-    margin-top: 10px;
   }
 }

--- a/app/views/channels/videos/partials/_streamer_profile.html.haml
+++ b/app/views/channels/videos/partials/_streamer_profile.html.haml
@@ -24,5 +24,6 @@
         %button.follow-btn{data: { action: "click->authentication#showModal" }} Follow
 
 
-  .streamer-info-mobile__about
-    = current_channel.about
+  - unless current_channel.about.blank?
+    .streamer-info-mobile__about
+      = current_channel.about

--- a/app/views/channels/videos/show.html.haml
+++ b/app/views/channels/videos/show.html.haml
@@ -23,6 +23,7 @@
       = render partial: "channels/videos/partials/streamer_profile"
 
     = render partial: "channels/videos/partials/recent_broadcasts"
+    = render partial: "layouts/footer"
 
   .content-area__secondary
     %canvas.fixed-secondary-canvas{

--- a/app/views/discover/index.html.haml
+++ b/app/views/discover/index.html.haml
@@ -1,11 +1,21 @@
 
 .content-area
-  - if @live_videos.any?
-    %h2 Live Videos!
-    .live-videos
-      = render collection: @live_videos, partial: "shared/video_card"
+  .discover-area
+    - if @live_videos.any?
+      %h2 Live Broadcasts
+      .live-broadcasts
+        = render collection: @live_videos.limit(3), partial: "shared/video_card"
 
-  %h2 Recent Videos
-  .videos
-    = render collection: @recent_videos, partial: "shared/video_card"
+    %h2 Popular streamers
+    .popular-streamers__container
+      .popular-streamers
+        - Channel.most_popular.limit(8).each do |channel|
+          .streamer-picture
+            %a{href: channel_path(channel.slug)}
+              = channel.decorate.profile_image_circle(100)
+
+    %h2 Featured Replays
+    .recent-broadcasts
+      = render collection: @recent_videos, partial: "shared/video_card"
+
   = render partial: "layouts/footer"


### PR DESCRIPTION
This PR of the changes introduced in #276  [VEUE-460] which redesigned the discover page. 

- Fixes the damn footer!!
- The double scroll nonsense is gone
- Footer now stretches to full container width
- Footer now behaves like a footer should...good footer
- Moves footer height and header height into `utils/scale.scss


<img width="401" alt="Screen Shot 2021-01-22 at 9 30 35 AM" src="https://user-images.githubusercontent.com/26425882/105762096-f261fe80-5f21-11eb-86e8-90130fcfb3af.png">
<img width="554" alt="Screen Shot 2021-01-25 at 3 19 55 PM" src="https://user-images.githubusercontent.com/26425882/105762097-f2fa9500-5f21-11eb-974c-e679e2cc55c1.png">
<img width="1440" alt="Screen Shot 2021-01-25 at 3 22 48 PM" src="https://user-images.githubusercontent.com/26425882/105762098-f2fa9500-5f21-11eb-86f5-04293d4c68a7.png">
<img width="1440" alt="Screen Shot 2021-01-25 at 3 22 59 PM" src="https://user-images.githubusercontent.com/26425882/105762099-f3932b80-5f21-11eb-8e4a-6a205e2cf338.png">
<img width="748" alt="Screen Shot 2021-01-25 at 3 23 04 PM" src="https://user-images.githubusercontent.com/26425882/105762102-f3932b80-5f21-11eb-9eca-e865202c2be7.png">
<img width="1440" alt="Screen Shot 2021-01-25 at 3 23 14 PM" src="https://user-images.githubusercontent.com/26425882/105762105-f42bc200-5f21-11eb-95ec-956524391454.png">





`
- Screenshots, because a picture is worth 1000 words...or something

