### PR TITLE
[Veue 480]: User chat messages appear even if rejected

### DIFF
--- a/app/controllers/channels/live/chat_messages_controller.rb
+++ b/app/controllers/channels/live/chat_messages_controller.rb
@@ -14,7 +14,7 @@ module Channels
           return
         end
 
-        render(json: {success: true})
+        render(json: {success: true, message: message.to_hash})
       end
 
       def index

--- a/app/javascript/helpers/authentication_helpers.ts
+++ b/app/javascript/helpers/authentication_helpers.ts
@@ -8,6 +8,12 @@ export function currentUserId(): string | undefined {
   return element?.getAttribute("data-user-id");
 }
 
+export function currentUserName(): string {
+  return document
+    .querySelector("*[data-user-name]")
+    .getAttribute("data-user-name");
+}
+
 function showLoginElements(): void {
   const loggedIn = !!currentUserId();
 

--- a/app/javascript/helpers/channel_helpers.ts
+++ b/app/javascript/helpers/channel_helpers.ts
@@ -9,3 +9,9 @@ export function getChannelSlug(): string {
     .querySelector("*[data-channel-slug]")
     .getAttribute("data-channel-slug");
 }
+
+export function getChannelUserId(): string {
+  return document
+    .querySelector("*[data-channel-user-id]")
+    .getAttribute("data-channel-user-id");
+}

--- a/app/javascript/helpers/chat_helpers.ts
+++ b/app/javascript/helpers/chat_helpers.ts
@@ -1,0 +1,103 @@
+import { ChatMessage, RenderChatMessageToString } from "types/chat";
+import { getChannelUserId } from "helpers/channel_helpers";
+import { currentUserId } from "helpers/authentication_helpers";
+
+export function appendToChat(element: HTMLElement, html: string): void {
+  element.insertAdjacentHTML("beforeend", html);
+  element.lastElementChild.scrollIntoView({
+    behavior: "smooth",
+    block: "start",
+    inline: "nearest",
+  });
+}
+
+export function renderChatMessageToString({
+  message,
+  isSameUser,
+  currentUserId,
+}: RenderChatMessageToString): string {
+  // Prepend message because document.querySelector("#1") will return an error
+  message.id = `message-${message.id}`;
+
+  if (message.byStreamer) {
+    return renderMessageByStreamer(message);
+  }
+
+  if (message.userId === currentUserId) {
+    return renderMessageBySelf(message);
+  }
+
+  if (isSameUser) {
+    return renderMessageBySameUser(message);
+  }
+
+  return renderRegularMessage(message);
+}
+
+export function displayChatMessage(
+  message: ChatMessage,
+  isSameUser: boolean
+): void {
+  if (document.querySelector(`#message-${message.id}`)) {
+    return;
+  }
+
+  const html = renderChatMessageToString({
+    message,
+    isSameUser,
+    currentUserId: currentUserId(),
+  });
+
+  appendToChat(document.querySelector(".messages"), html);
+}
+
+export function byStreamer(): boolean {
+  return this.myUserId === getChannelUserId();
+}
+
+function renderMessageByStreamer(message: ChatMessage) {
+  return `
+    <div id="${message.id}" class="message-left">
+      <div class="highlighted-message">
+        <div class="highlighted-message__name">
+          ${message.name}
+        </div>
+        <div class="message-display border-left highlighted-message__text">
+          ${message.message}
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function renderMessageBySelf(message: ChatMessage) {
+  return `
+    <div id="${message.id}" class="message-right">
+      <div class="message-display message-right__text">
+        ${message.message}
+      </div>
+    </div>`;
+}
+
+function renderMessageBySameUser(message: ChatMessage) {
+  return `
+    <div id="${message.id}" class="message-grouped">
+      <div class="message-display border-left message-grouped__text">
+        ${message.message}
+      </div>
+    </div>`;
+}
+
+function renderRegularMessage(message: ChatMessage) {
+  return `
+    <div id="${message.id}" class="message-left">
+      <div class="message-content">
+        <div class="message-content__name">
+          ${message.name}
+        </div>
+        <div class="message-display border-left message-content__text">
+          ${message.message}
+        </div>
+      </div>
+    </div>`;
+}

--- a/app/javascript/helpers/event/event_processor.ts
+++ b/app/javascript/helpers/event/event_processor.ts
@@ -41,8 +41,6 @@ export const VideoEventProcessor = new (class VideoEventProcessor {
     this.dispatcher.addEventListener(videoEventType, callback);
   }
 
-  private;
-
   dispatch(videoEvent: VideoEvent): void {
     console.log(
       "dispatching",

--- a/app/javascript/types/chat.ts
+++ b/app/javascript/types/chat.ts
@@ -1,0 +1,13 @@
+export interface ChatMessage {
+  id: string;
+  message: string;
+  userId: string;
+  name: string;
+  byStreamer: boolean;
+}
+
+export interface RenderChatMessageToString {
+  message: ChatMessage;
+  isSameUser: boolean;
+  currentUserId: string;
+}

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ChatMessage < VideoEvent
+  validates :text, presence: true
+
   def input_to_payload
     {
       name: user.display_name,
@@ -15,12 +17,12 @@ class ChatMessage < VideoEvent
       properties: {
         message: String,
       },
-      required: ["message"],
+      required: %w[message],
     }
   end
 
   def text
-    payload["message"]
+    input["message"]
   end
 
   # Immediately deliver via channel

--- a/app/models/video_event.rb
+++ b/app/models/video_event.rb
@@ -50,7 +50,7 @@ class VideoEvent < ApplicationRecord
     {
       type: type,
       timecodeMs: timecode_ms,
-      data: payload,
+      data: payload.merge({id: id}),
     }
   end
 

--- a/app/views/broadcasts/show.html.haml
+++ b/app/views/broadcasts/show.html.haml
@@ -10,7 +10,9 @@
       "video-id": current_broadcast_video.id,
       "video-visibility": current_broadcast_video.visibility,
       "channel-id": current_broadcast_video.channel.id,
-      "channel-slug": current_broadcast_video.channel.slug
+      "channel-slug": current_broadcast_video.channel.slug,
+      "channel-user-id": current_broadcast_video.user.id,
+      "user-name": current_user.display_name,
     }
   }
   .content-area

--- a/app/views/channels/channels/show.html.haml
+++ b/app/views/channels/channels/show.html.haml
@@ -1,7 +1,8 @@
 .channel-page{
   "data": {
     "controller": "channel",
-    "channel-id": current_channel.id
+    "channel-id": current_channel.id,
+    "channel-user-id": current_channel.user.id,
   }
 }
   - if upcoming_stream?

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -9,6 +9,7 @@
         "data": {
           "controller": "user-menu",
           "user-id": current_user.id,
+          "user-name": current_user.display_name,
           "target": "user-menu.area",
           "is-open": "false",
           "action": "mouseenter->user-menu#openOrCloseEvent mouseleave->user-menu#openOrCloseEvent resize@window->user-menu#layout click->user-menu#openOrCloseEvent"

--- a/app/views/shared/_chat.html.haml
+++ b/app/views/shared/_chat.html.haml
@@ -40,7 +40,8 @@
           role: "textbox",
           data: {
             action: "keydown->chat--send-message#chatBoxKeyDown",
-            target: "chat--send-message.messageInput"
+            target: "chat--send-message.messageInput",
+            "message-key": SecureRandom.uuid
           }
         }
         = render "shared/reaction_button"

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -2,7 +2,15 @@
 
 require "rails_helper"
 
-describe ChatMessage do
+describe ChatMessage, type: :model do
+  describe "Record creation" do
+    it "Should fail if called with an empty message" do
+      expect {
+        create(:chat_message, input: {message: " " * 6})
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
   describe "Publishing and filtering" do
     it "should publish if it passes" do
       create(:chat_message)

--- a/spec/support/audience_spec_helpers.rb
+++ b/spec/support/audience_spec_helpers.rb
@@ -40,7 +40,11 @@ module AudienceSpecHelpers
   end
 
   def someone_chatted(message=Faker::Quote.most_interesting_man_in_the_world, timecode_ms=0)
-    video.chat_messages.create!(user: create(:user), input: {message: message}, timecode_ms: timecode_ms)
+    video.chat_messages.create!(
+      user: create(:user),
+      input: {message: message},
+      timecode_ms: timecode_ms,
+    )
   end
 
   def streamer_visited(url, timecode_ms)

--- a/spec/system/live_audience/chat_system_spec.rb
+++ b/spec/system/live_audience/chat_system_spec.rb
@@ -23,7 +23,7 @@ describe "chat during live video" do
     it "should allow for live chat messages to be sent" do
       write_chat_message "Cowabunga!"
       expect(page).to have_content("Cowabunga!").once
-      expect(video.chat_messages.count).to be(1)
+      expect(video.chat_messages.count).to eq(1)
 
       # This seems odd, I know, but it's the main way to repo VEUE-144
       # as Turbolinks with the page transitions was doubling the number
@@ -111,10 +111,13 @@ describe "chat during live video" do
       expect(page).to have_content(first_message.user.display_name)
     end
 
-    it "should have hilighted comment of streamer" do
+    it "should have highlighted comment of streamer" do
+      expect(page).not_to(have_selector(".message-write"))
+
       # It is mocking comment of streamer
       login_as video.user
       write_chat_message "Cowabunga!"
+      expect(page).to have_content("Cowabunga!").once
       logout_user
 
       # Watching stream as a common visitor
@@ -129,6 +132,18 @@ describe "chat during live video" do
       find(".message-login-prompt").click
 
       expect(page).to have_css("#phone_number_input")
+    end
+
+    it "should show the message even if rejected" do
+      PerspectiveApi.key = "FAIL"
+      login_as user
+      bad_word = "profanity"
+      write_chat_message bad_word
+      expect(page).to have_content(bad_word)
+
+      visit channel_path(channel)
+
+      expect(page).to have_no_content(bad_word)
     end
   end
 end


### PR DESCRIPTION
# What this PR does?

This PR attaches idempotency keys to every `VideoEvent`, its really just the `id` of the VideoEvent thats its attaching to the `event.detail`, nothing fancy here.

- Moves rendering to a helper so that it can be used both on send and on event firing
- Mostly just a minor refactor of bits and pieces.

This also fixes VEUE-492