### PR TITLE
[VEUE-466]: Prevent new window creation in the main window

### DIFF
--- a/broadcaster/src/BrowserViewManager.ts
+++ b/broadcaster/src/BrowserViewManager.ts
@@ -33,6 +33,7 @@ export default class BrowserViewManager {
     webContents.on("new-window", (event, url) => {
       console.log("Popup creation prevented for: ", url);
       event.preventDefault();
+      this.browserView.webContents.loadURL(url);
     });
 
     this.window.addBrowserView(this.browserView);


### PR DESCRIPTION
- New windows can no longer be created within the main window.
- Popups are already blocked by default in Electron when within a `<webview>` https://www.electronjs.org/docs/all#10-do-not-use-allowpopups

Heres a video of me trying to click the `view file` which used to create a new window.

https://user-images.githubusercontent.com/26425882/106331279-9f09ec00-6252-11eb-8ea6-71bb88b56fa4.mov

