### PR TITLE
VEUE-483 - Alignment of colors of displayed elements when hovering

### DIFF
--- a/app/javascript/style/video/_header_bar.scss
+++ b/app/javascript/style/video/_header_bar.scss
@@ -106,7 +106,7 @@
         text-align: center;
         position: absolute;
         left: -50px;
-        top: 55px;
+        top: 42px;
 
         @include smallTall() {
           left: -107px;
@@ -125,7 +125,7 @@
             border-right: 6px solid transparent;
             border-bottom: 5px solid color.$neutral-dark;
             content: "";
-            left: 93px;
+            left: 86px;
             top: -5px;
             @include smallTall() {
               left: 75%;


### PR DESCRIPTION
### VEUE-483 - Alignment of colors of displayed elements when hovering

Change the color of the REPLAY button and the hover over as requested on the ticket. Took the liberty to fix the alignment of the little triangle that shows there and also the spacing between the button and the body, according to the [Figma](https://www.figma.com/file/vltEMijbTdGj3NE5AAS34T/VOD-Replay?node-id=0%3A1).

### Before:
![body](https://user-images.githubusercontent.com/59073973/106623786-952a0680-653a-11eb-91a4-55da62d43f4a.png)
### After: 
![fix_body](https://user-images.githubusercontent.com/59073973/106623787-95c29d00-653a-11eb-8748-1b1f175e8494.png)
