### PR TITLE
[VEUE-507]: Possible fix for double broadcasting

### DIFF
--- a/app/models/video_event.rb
+++ b/app/models/video_event.rb
@@ -8,7 +8,7 @@ class VideoEvent < ApplicationRecord
   before_save :set_payload
   before_create :set_timecode
   before_create :set_published_state
-  after_create :broadcast_message!
+  after_commit :broadcast_message!, on: :create
 
   validates :video, presence: true
   validates :input, json: {schema: -> { input_schema.to_json }}


### PR DESCRIPTION
So I dont believe idempotency keys solve this issue. Theres appears to be mutliple threads about `after_create` firing twice and I came along this article which explained briefly what was going on. https://www.justinweiss.com/articles/a-couple-callback-gotchas-and-a-rails-5-fix/

The reason we dont see this in production is that its all on the same database and the commit happens at the same time so theres no transactions between databases to worry about. This *should* fix the double broadcasting issue we've been seeing in testing...hopefully

