### PR TITLE
[VEUE-491]: Implement Rate limiting on user join events

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -127,6 +127,26 @@ class Video < ApplicationRecord
     schedule!
   end
 
+  def last_join_time_cache_location
+    "last_user_join_time_#{id}"
+  end
+
+  def time_since_last_user_joined
+    now = Integer(Time.current)
+    now - Integer(last_user_join_time)
+  end
+
+  def last_user_join_time
+    @last_user_join_time ||=
+      Rails.cache.fetch(last_join_time_cache_location) {
+        last_join = UserJoinedEvent.last
+
+        return 0 if last_join.nil?
+
+        Integer(last_join.created_at.utc)
+      }
+  end
+
   private
 
   def after_go_live

--- a/config/initializers/rate_limiting.rb
+++ b/config/initializers/rate_limiting.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+USER_JOIN_RATE_LIMIT_SECONDS = Integer(ENV.fetch("USER_JOIN_RATE_LIMIT_SECONDS", "5"), 10)

--- a/spec/models/video_view_spec.rb
+++ b/spec/models/video_view_spec.rb
@@ -46,8 +46,11 @@ RSpec.describe VideoView, type: :model do
 
       # This fishy person does NOT get a new user joined event
       expect(video.user_joined_events.count).to eq(1)
-
       # If you are actually looking like a new person...
+
+      # Stub the rails cache fetch to be greater than 5 seconds
+      expect(Rails.cache).to receive(:fetch).and_return(Integer(6.seconds.ago))
+
       VideoView.process_view!(video, second_user, 4, "NEW FINGERPRINT", true)
       # And you even get announced!
       expect(video.user_joined_events.count).to eq(2)

--- a/spec/requests/user_joined_events_spec.rb
+++ b/spec/requests/user_joined_events_spec.rb
@@ -10,11 +10,23 @@ describe Channels::VideosController do
     end
 
     describe "for live videos" do
+      let(:video) { create(:live_video) }
       it "should create a new user joined event" do
-        video = create(:live_video)
         expect(video.user_joined_events.size).to eq(0)
         post viewed_channel_video_url(video.channel, video, minute: 1)
         post viewed_channel_video_url(video.channel, video, minute: 1)
+        post viewed_channel_video_url(video.channel, video, minute: 1)
+        expect(video.user_joined_events.reload.size).to eq(1)
+      end
+
+      it "should not create a user_joined_event if less than 5 seconds have passed since the previous" do
+        expect(Rails.cache).to receive(:fetch).and_return(Integer(3.seconds.ago))
+        post viewed_channel_video_url(video.channel, video, minute: 1)
+        expect(video.user_joined_events.reload.size).to eq(0)
+      end
+
+      it "should create a 2nd_user_joined event if greater than 5 seconds have passed" do
+        expect(Rails.cache).to receive(:fetch).and_return(Integer(6.seconds.ago))
         post viewed_channel_video_url(video.channel, video, minute: 1)
         expect(video.user_joined_events.reload.size).to eq(1)
       end


### PR DESCRIPTION
- Uses the cache to find the time of the last created user_join_event so it doesnt constantly jam the DB.
- When a new user_join_event is created, it gets written to the cache
- Adds a request spec around the user joined event
- Fixes the VideoView model spec that broke as a result of the new delay. 