### PR TITLE
VEUE-518 - fix for bio textarea not expand

### DIFF
--- a/app/javascript/style/user_profile/_tabs.scss
+++ b/app/javascript/style/user_profile/_tabs.scss
@@ -77,6 +77,7 @@
           }
           textarea {
             height: 102px;
+            resize: none;
           }
           .input-field {
             width: 100%;


### PR DESCRIPTION
### VEUE-518 - fix for bio textarea not  expand

Fix to prevent the Bio textarea to expand.

Files changed: 

- _tabs.scss