### PR TITLE
VEUE-502 - Galaxy Fold - Play Button

### DIFF
--- a/app/javascript/style/components/_video_card.scss
+++ b/app/javascript/style/components/_video_card.scss
@@ -80,12 +80,20 @@
       position: absolute;
       top: 40%;
       left: 40%;
+      z-index: 1;
       > svg {
         background-color: color.$veue-corporate;
         border-radius: 10px;
         height: 25px;
         width: 25px;
         padding: 16px 15px 14px 19px;
+      }
+      @media screen and (max-width: 280px) {
+        > svg {
+          height: 15px;
+          width: 15px;
+          padding: 10px 9px 9px 10px;
+        }
       }
     }
 


### PR DESCRIPTION
### VEUE-502 - play button changes on galaxy fold resolution

What I have done to fix the button on Galaxy Fold:

- Play was appearing beneath the streamer's picture. Fix: z-index.

- Play was too big for that resolution. Fix: added a specific media query for that resolution and made a little smaller.

Both changes were made at:

- _video_card.scss

View of how it looks now:
![galaxy_play](https://user-images.githubusercontent.com/59073973/106789399-d47a5500-6617-11eb-96b7-06bae62186b8.png)
