### PR TITLE
[VEUE-568]: Fix replay date positioning on Safari

### DIFF
--- a/app/javascript/style/video/_header_bar.scss
+++ b/app/javascript/style/video/_header_bar.scss
@@ -91,7 +91,6 @@
       color: color.$white;
       font-weight: font.$heavy-weight;
       position: relative;
-      z-index: 1;
 
       &:hover {
         background: color.$neutral-darker;


### PR DESCRIPTION
- Apparently Safari loses its mind if the parent of an absolute element has a z-index specified.

## Before

<img width="259" alt="Screen Shot 2021-02-18 at 8 59 27 AM" src="https://user-images.githubusercontent.com/26425882/108367621-a2e0bc80-71c7-11eb-8be4-18c7ee409ddb.png">


## After

<img width="239" alt="Screen Shot 2021-02-18 at 8 59 14 AM" src="https://user-images.githubusercontent.com/26425882/108367641-a7a57080-71c7-11eb-9d8c-c59d5a7710b2.png">

