### PR TITLE
[VEUE-564]: Fix header bar display issue on Safari

### DIFF
--- a/app/javascript/style/components/_user_menu.scss
+++ b/app/javascript/style/components/_user_menu.scss
@@ -9,6 +9,9 @@
   display: flex;
   align-items: center;
 
+  // Safari workaround for improper widths...
+  justify-content: flex-end;
+
   // There is a second chevron in the mobile
   // view, so we have to be extra clear on which
   // one is being addressed


### PR DESCRIPTION
- Fix positioning of header bar on safari

## Before

<img width="926" alt="Screen Shot 2021-02-18 at 9 34 50 AM" src="https://user-images.githubusercontent.com/26425882/108372265-a165c300-71cc-11eb-8f08-0b3ced609269.png">

## After

<img width="926" alt="Screen Shot 2021-02-18 at 9 35 15 AM" src="https://user-images.githubusercontent.com/26425882/108372313-adea1b80-71cc-11eb-8ecf-bcb2fc1a485c.png">
