### PR TITLE
Fix broken broadcaster setting form spec

### DIFF
--- a/spec/system/broadcast_spec.rb
+++ b/spec/system/broadcast_spec.rb
@@ -244,7 +244,7 @@ describe "Broadcast View" do
         expect(video.visibility).to eq(new_visibility)
       end
 
-      it "properly displays flash errors" do
+      it "properly displays flash message on save" do
         new_title = "*" * 75
         within(settings_form) do
           fill_in("video_title", with: new_title)


### PR DESCRIPTION
So changed the failure message to success because browser automatically limit characters to 70 on input when maxlength attr is present. So title will be saved!!!