### PR TITLE
[VEUE-590] Larger Video Size

### DIFF
--- a/app/javascript/helpers/broadcast/mixers/video_mixer.ts
+++ b/app/javascript/helpers/broadcast/mixers/video_mixer.ts
@@ -5,7 +5,7 @@ import Mixer from "helpers/broadcast/mixers/mixer";
 import { buildBroadcastLayout } from "util/layout_packer";
 import { sendBroadcastLayoutUpdate } from "helpers/broadcast_helpers";
 
-const VIDEO_SIZE = { width: 1280, height: 1080 };
+const VIDEO_SIZE = { width: 1920, height: 1080 };
 export const BroadcastLayoutChangedEvent = "BroadcastLayoutChanged";
 
 export default class VideoMixer implements Mixer {


### PR DESCRIPTION
Mux actually allows us to use a wider video stream than we were using. I totally missed there were two "HD" sizes, so this will give us better video quality with almost no tradeoffs!

WIN WIN!