### PR TITLE
[VEUE-597] Tests for User Profile Edit

### DIFF
--- a/app/javascript/controllers/profile_edit_controller.ts
+++ b/app/javascript/controllers/profile_edit_controller.ts
@@ -31,7 +31,7 @@ export default class extends Controller {
       const html = await response.text();
       this.formTarget.parentElement.innerHTML = html;
 
-      showNotification("Your profile was succesfully updated");
+      showNotification("Your profile was successfully updated");
     }
   }
 }

--- a/app/views/users/partials/_edit_form.html.haml
+++ b/app/views/users/partials/_edit_form.html.haml
@@ -17,14 +17,14 @@
       = render partial: "users/partials/upload_image"
     .profile-update
       .profile-update__heading
-        Public Name
+        %label{for: "user_display_name"} Public Name
         .heading-info
           Real People, Real Names
       .profile-update__field
-        = f.text_field :display_name, class: 'input-field', placeholder: 'Enter your name', maxlength: "30"
+        = f.text_field :display_name, class: 'input-field', placeholder: 'Enter your name', maxlength: "20"
     .profile-update
       .profile-update__heading
-        Bio
+        %label{for: "user_about_me"} Bio
         .heading-info
           Let us know about you
       .profile-update__field
@@ -36,7 +36,7 @@
         = f.text_field :masked_phone_number, class: 'input-field', :disabled => true
     .profile-update
       .profile-update__heading
-        Email
+        %label{for: "user_email"} Email
         .heading-info
           Add your email for notifications
       .profile-update__field

--- a/spec/system/user_profile_spec.rb
+++ b/spec/system/user_profile_spec.rb
@@ -58,7 +58,23 @@ describe "user profile" do
 
         find("#user_email").base.send_keys("test@user.com", :enter)
 
-        expect(page).to have_content("Your profile was succesfully updated")
+        expect(page).to have_content("Your profile was successfully updated")
+      end
+
+      it "should stop you from entering too much text!" do
+        click_link "Profile"
+
+        long_text = "Hampton Is So Cool! " * 100
+
+        fill_in "Public Name", with: long_text
+        fill_in "Bio", with: long_text
+        click_on "Save Changes"
+
+        expect(page).to have_content("Your profile was successfully updated")
+
+        user.reload
+        expect(user.display_name).to eq(long_text.first(20))
+        expect(user.about_me).to eq(long_text.first(160))
       end
     end
 


### PR DESCRIPTION
This is to fix a bug where the form lets you enter 30 characters in your Display Name, but the DB only let’s 20.

However, we also had not a lot of tests so I tested that we actually update the DB with new user data after editing a profile.