### PR TITLE
[VEUE-607]: Add tap to unmute banner

### DIFF
--- a/app/helpers/videos_helper.rb
+++ b/app/helpers/videos_helper.rb
@@ -59,7 +59,7 @@ module VideosHelper
       class: classes,
       title: "Toggle Audio",
       data: {
-        action: "click->audience-view#toggleAudio",
+        action: "click->audience-view#toggleAudio click->audience-view#hideMuteBanner",
         target: "audience-view.toggleAudio",
       },
     ) do

--- a/app/javascript/controllers/audience_view_controller.ts
+++ b/app/javascript/controllers/audience_view_controller.ts
@@ -29,6 +29,7 @@ export default class extends BaseController {
     "toggleAudio",
     "timeDisplay",
     "timeDuration",
+    "muteBanner",
   ];
 
   readonly togglePlayTargets!: HTMLElement[];
@@ -39,6 +40,7 @@ export default class extends BaseController {
   readonly pipSecondaryCanvasTarget!: HTMLCanvasElement;
   readonly timeDisplayTarget!: HTMLElement;
   readonly timeDurationTarget!: HTMLElement;
+  readonly muteBannerTarget!: HTMLElement;
 
   private broadcastLayout: BroadcastVideoLayout;
   private timecodeSynchronizer: TimecodeSynchronizer;
@@ -149,6 +151,7 @@ export default class extends BaseController {
         .catch(() => {
           this.state = "paused";
           this.audioState = "muted";
+          this.showMuteBanner();
           this.videoTarget
             .play()
             .then(() => (this.state = "playing"))
@@ -196,6 +199,14 @@ export default class extends BaseController {
 
   hideChat(): void {
     this.element.className = "content-area";
+  }
+
+  showMuteBanner(): void {
+    this.muteBannerTarget.style.display = "flex";
+  }
+
+  hideMuteBanner(): void {
+    this.muteBannerTarget.style.display = "none";
   }
 
   set state(state: string) {

--- a/app/javascript/style/utils/z_index.scss
+++ b/app/javascript/style/utils/z_index.scss
@@ -19,6 +19,9 @@ $chat-reaction: next-z-index();
 // The main video, that might be under other video elements
 $primary-video: next-z-index();
 
+// The unmuted banner that flashes in front of the primary video
+$mute-banner: next-z-index();
+
 // Video areas that might appear on top of the primary video such as PIP
 $secondary-video: next-z-index();
 

--- a/app/javascript/style/video/_layout.scss
+++ b/app/javascript/style/video/_layout.scss
@@ -1,5 +1,7 @@
 @use "../utils/breakpoints" as *;
 @use "../utils/scale";
+@use "../utils/color";
+@use "../utils/z_index";
 
 #videos__show,
 #channels__show {
@@ -38,6 +40,29 @@
 
     canvas.pip-secondary-canvas {
       border-radius: 10px;
+    }
+
+    .mute-banner {
+      // layout
+      position: absolute;
+      z-index: z_index.$mute-banner;
+      left: 0.6rem;
+      top: 1rem;
+      height: 2rem;
+      padding: 0 1rem;
+      display: flex;
+      align-items: center;
+
+      // style
+      background: rgba(color.$black, 0.5);
+      color: color.$white;
+      border-radius: 10px;
+      font-size: 1.1rem;
+      cursor: pointer;
+
+      svg {
+        margin-right: 10px;
+      }
     }
   }
 

--- a/app/views/channels/videos/show.html.haml
+++ b/app/views/channels/videos/show.html.haml
@@ -16,6 +16,9 @@
   .content-area__primary{data: {controller: "canvas-size-observer"}}
     = render partial: "channels/videos/partials/header"
     .primary-video{"data": { controller: "audience--movable-pip" }}
+      .mute-banner{style: "display: none;", data: { target: "audience-view.muteBanner", action: "click->audience-view#toggleAudio click->audience-view#hideMuteBanner"}}
+        = svg_tag("volume-mute", height: 14, width: 19)
+        = t("video.tap_to_unmute")
       %canvas.primary-canvas{
         "data-target": "audience-view.primaryCanvas canvas-size-observer.canvas",
         width: 1200,
@@ -33,7 +36,7 @@
       "data-target": "audience-view.fixedSecondaryCanvas",
       width: 420,
       height: 340
-    } 
+    }
     %video.player__video.viewer{
       "data-target": "audience-view.video audience--player-controls.video",
       crossorigin: "anonymous",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,3 +91,7 @@ en:
       title: "%{name} on Veue"
     seo:
       title: "%{name} on Veue"
+  video:
+    tap_to_unmute: "Tap to unmute"
+
+

--- a/spec/system/broadcast/video_schedule_spec.rb
+++ b/spec/system/broadcast/video_schedule_spec.rb
@@ -10,10 +10,6 @@ describe "Streamer scheduling" do
   let(:streamer) { channel.user }
   let(:video) { channel.videos.active.last }
 
-  before :example do
-    driven_by :selenium, using: :chrome
-  end
-
   before :each do
     visit "/"
     find("body").click

--- a/spec/system/vod_audience_spec.rb
+++ b/spec/system/vod_audience_spec.rb
@@ -115,6 +115,7 @@ describe "Prerecorded Audience View" do
 
       expect(page).to have_css("[data-start-offset='#{start_offset}']")
       expect(is_video_playing?).to be(true)
+      byebug
 
       # We actually have no clue where in the time code we'll be, but its safe
       # to assume we'll be greater than 0.
@@ -147,6 +148,23 @@ describe "Prerecorded Audience View" do
       # Use 26 to account for possible rounding issues.
       # Use a float because video durations on a video element are floats
       expect(Float(find("#duration-time-display")["data-duration"])).to be <= 26.0
+    end
+  end
+
+  describe "Unmute banner" do
+    it "Should display when the video is visited and disappear when clicked" do
+      visit path_for_video(video)
+      expect(find(".mute-banner")).to have_content(I18n.t("video.tap_to_unmute"))
+
+      find(".mute-banner").click
+      expect(find(".mute-banner", visible: false)).to_not be_visible
+    end
+
+    it "Should disappear when the user clicks the player control mute button" do
+      visit path_for_video(video)
+      expect(page).to have_css(".mute-banner")
+      find(".toggle-audio", visible: true).click
+      expect(find(".mute-banner", visible: false)).to_not be_visible
     end
   end
 end


### PR DESCRIPTION
- Adds a tap to unmute banner
- Some liberties were taken, I didnt split `tap` / `click` like in the design (I think tap is universally understood, and it makes implementation easier, IE: when do we go from tap to click? The user could be on an ipad Pro, etc, happy to put in click instead if we want)
- Removed the "audio" after the `tap to unmute` simply because it feels redundant
- Unmuting using either the actual unmute button or the tap to unmute causes it to disappear and not reappear.
- Adds a z-index for it.
- Only gets triggered if theres an error playing the video.


https://user-images.githubusercontent.com/26425882/110721787-30b83200-81df-11eb-8581-353b95fa5067.mov



