### PR TITLE
[VEUE-625] AppSignal Errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    appsignal (2.11.9)
+    appsignal (3.0.1)
       rack
     arbre (1.4.0)
       activesupport (>= 3.0.0, < 6.2)

--- a/app/models/video_view.rb
+++ b/app/models/video_view.rb
@@ -42,11 +42,8 @@ class VideoView < ApplicationRecord
 
     minute = Integer(minute, 10) unless minute.is_a?(Integer)
 
-    # If this is the same as the LAST minute we saw, don't count it again
-    # aka, we might be paused or refresh the page... so you don't get extra minutes for that!
-    if video_view_minutes.order("created_at ASC").last&.minute != minute
-      video_view_minutes.build(minute: minute, is_live: is_live)
-    end
+    # Only count video view minutes for unique minutes (both live and not live)
+    video_view_minutes.build(minute: minute, is_live: is_live) if video_view_minutes.where(minute: minute).none?
 
     save!
   end


### PR DESCRIPTION
I’ve tweaked appsignal settings, purged failed jobs, and found this common error we were getting with duplicate watch minutes.

(The validation was failing on the `save!)