### PR TITLE
[VEUE-636] Broadcaster Bugfixes

### DIFF
--- a/.idea/veue.iml
+++ b/.idea/veue.iml
@@ -75,7 +75,7 @@
     <orderEntry type="library" scope="PROVIDED" name="activestorage-validator (v0.1.3, RVM: ruby-2.7.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="activesupport (v6.1.3, RVM: ruby-2.7.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="addressable (v2.7.0, RVM: ruby-2.7.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="appsignal (v2.11.9, RVM: ruby-2.7.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="appsignal (v3.0.1, RVM: ruby-2.7.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="arbre (v1.4.0, RVM: ruby-2.7.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="argon2-kdf (v0.1.5, RVM: ruby-2.7.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.2, RVM: ruby-2.7.2) [gem]" level="application" />

--- a/broadcaster/src/BrowserViewManager.ts
+++ b/broadcaster/src/BrowserViewManager.ts
@@ -18,7 +18,11 @@ export default class BrowserViewManager {
 
   constructor(window: BrowserWindow, bounds: Rectangle, url: string) {
     this.window = window;
-    this.browserView = new BrowserView();
+    this.browserView = new BrowserView({
+      webPreferences: {
+        disableHtmlFullscreenWindowResize: true,
+      },
+    });
     const { webContents } = this;
 
     // Now we want ot subscribe to the following events and send them to the main window

--- a/broadcaster/src/main.ts
+++ b/broadcaster/src/main.ts
@@ -28,10 +28,8 @@ app.setAppUserModelId("com.veue.deskie");
 // Prevent window from being garbage collected
 let broadcasterApp;
 
-// power-save-blocker
-// for more info see https://www.electronjs.org/docs/api/power-save-blocker
-const psb_id = powerSaveBlocker.start("prevent-app-suspension");
-console.log(`POWER SAVE BLOCKER ${powerSaveBlocker.isStarted(psb_id)}`); // interestingly this logs to STDOUT in the running Node (electron) app
+// Stop the renderer from getting backgrounded when it loses focus
+app.commandLine.appendSwitch("disable-renderer-backgrounding");
 
 app.on("login", function (event, webContents, request, authInfo, callback) {
   event.preventDefault();


### PR DESCRIPTION
Several changes in this PR:

1) Power Saving - Jason’s previous implementation of powerSaveBlocker was stopping app suspension when the app was open. In this version it’s during a broadcast that we stop the display from going to sleep

2) Background Throttling - Further, the original bug that we were trying to fix when the Broadcaster isn’t visible on the desktop, the ffmpeg would fail. Turns out this isn’t because the Render process failed, but because the page itself stopped ‘feeding’ ffmpeg with new frames as chrome stops rendering canvases when not visible. Changed the flag for that.

3) Stop the BrowserView from maximizing it’s contents.