### PR TITLE
[VEUE-604] Set Locale for Perspective API

### DIFF
--- a/lib/perspective_api.rb
+++ b/lib/perspective_api.rb
@@ -59,6 +59,7 @@ module PerspectiveApi
         TOXICITY: {},
       },
       sessionId: stream_id,
+      languages: ["en"],
     }
   end
 


### PR DESCRIPTION
This sets locale to always be english for perspective API.

We _can_ do other languages in the future with changes, but for now this avoids the errors we were getting.