### PR TITLE
[VEUE-619] reduce joined message

### DIFF
--- a/app/javascript/controllers/chat/messages_controller.ts
+++ b/app/javascript/controllers/chat/messages_controller.ts
@@ -84,8 +84,7 @@ export default class MessagesController extends BaseController {
       this.element,
       `
       <div class="user-joined">
-        <img src=${userSvg} alt="user-icon"/>
-        <div>${user.name} joined the chat</div>
+        <div>${user.name} has joined</div>
       </div>`
     );
   }

--- a/app/javascript/style/chat.scss
+++ b/app/javascript/style/chat.scss
@@ -53,27 +53,20 @@
       }
 
       .user-joined {
-        background: color.$neutral-soft;
         color: color.$neutral-regular;
         display: flex;
         align-items: center;
-        margin-top: 10px;
-        margin-left: 10px;
+        justify-content: center;
+        margin: 10px 10px 0 10px;
         border-radius: 10px;
         padding: 3px 10px;
         min-height: 28px;
-        width: fit-content;
 
         div {
           margin-left: 6px;
           align-items: center;
           margin-right: 4px;
-        }
-
-        img {
-          color: white;
-          width: 12px;
-          margin-left: 4px;
+          text-align: center;
         }
       }
     }

--- a/spec/system/live_audience/chat_system_spec.rb
+++ b/spec/system/live_audience/chat_system_spec.rb
@@ -51,7 +51,7 @@ describe "chat during live video" do
 
     it "should show that you joined the chat" do
       assert_video_is_playing
-      expect(page).to have_content("#{user.display_name} joined the chat")
+      expect(page).to have_content("#{user.display_name} has joined")
     end
 
     it "should have visible scroll button after a bunch of messages" do
@@ -92,9 +92,9 @@ describe "chat during live video" do
     end
 
     it "should show you joined after you logged in" do
-      expect(page).to_not(have_content("#{user.display_name} joined the chat"))
+      expect(page).to_not(have_content("#{user.display_name} has joined"))
       login_as user
-      expect(page).to(have_content("#{user.display_name} joined the chat"))
+      expect(page).to(have_content("#{user.display_name} has joined"))
     end
 
     it "should not allow you to chat until you login" do


### PR DESCRIPTION
This PR changes `joined` message style and reduced message font-size to 14px.

<img width="1429" alt="Screenshot 2021-03-16 at 7 29 34 PM" src="https://user-images.githubusercontent.com/23502541/111326173-25a54c00-868e-11eb-9795-c95c5f0086b1.png">

<img width="409" alt="Screenshot 2021-03-16 at 7 27 51 PM" src="https://user-images.githubusercontent.com/23502541/111326148-2211c500-868e-11eb-940b-c3134a1afe9b.png">
