### PR TITLE
[VEUE-642] Follow Button Margin Problem

### DIFF
--- a/app/javascript/style/components/_streamer_profile.scss
+++ b/app/javascript/style/components/_streamer_profile.scss
@@ -72,6 +72,7 @@
       justify-content: center;
       align-items: center;
       padding: 10px 0;
+      margin-right: 10px;
 
       &__count {
         display: flex;
@@ -177,10 +178,6 @@
 
       &__mobile__about {
         display: none;
-      }
-
-      &__follow {
-        margin-right: 10px;
       }
     }
 


### PR DESCRIPTION
In the mobile views, the Follow button lost it’s margin to the right, so this PR puts it for both full screen and mobile sizes.