### PR TITLE
[VEUE-600] Stop Expanding Streamer Profile

### DIFF
--- a/app/javascript/controllers/streamer_profile_controller.ts
+++ b/app/javascript/controllers/streamer_profile_controller.ts
@@ -9,24 +9,22 @@ export default class extends BaseController {
 
   async follow(): Promise<void> {
     const response = await post(this.followPath());
-    return this.insertHTML(response);
+    return this.replaceHtml(response);
   }
 
   async unfollow(): Promise<void> {
     const response = await destroy(this.followPath());
-    return this.insertHTML(response);
+    return this.replaceHtml(response);
   }
 
   authChanged(): void {
     secureFetch(this.followPath()).then((response) =>
-      this.insertHTML(response)
+      this.replaceHtml(response)
     );
   }
 
-  private async insertHTML(response: Response): Promise<void> {
-    const html = await response.text();
-
-    this.element.innerHTML = html;
+  private async replaceHtml(response: Response): Promise<void> {
+    this.element.outerHTML = await response.text();
   }
 
   private followPath(): string {

--- a/spec/system/stream_follow_spec.rb
+++ b/spec/system/stream_follow_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe "Follow from VOD" do
         visit path_for_video(video)
         find(".unfollow-btn").click
 
+        expect(page).to have_css(".streamer-profile", count: 1)
+
         expect(page).to have_content("Follow")
         expect(page).to have_content("REPLAY")
       end


### PR DESCRIPTION
Because we were inserting the innerHTML of the thing that was… itself. We ended up making a lot of extra controllers and HTML causing a fun ‘nesting doll’ kind of effect with repeated follows / unfollows.

Here, we just swap it to replaceHTML

Also, the test is inline of another one just validating that we have one CSS entry for the streamer-profile.