### PR TITLE
[VEUE-648] Fixing Safari Canvas

### DIFF
--- a/app/javascript/style/video/_layout.scss
+++ b/app/javascript/style/video/_layout.scss
@@ -32,7 +32,6 @@
   .primary-video {
     // This is required to ensure that the controls can be shown over this area
     position: relative;
-    display: flex;
 
     canvas.primary-canvas {
       width: 100%;


### PR DESCRIPTION
The streamer profile area code included making the .primary-canvas as flex… which unfortunately borked Safari’s canvas math. Tested now on both devices

BUT! This does introduce a small gap between the primary video and the steamer info below, which is likely why this was included.

However, I’m calling this a show-stopper for now and we can fix it tomorrow.