### PR TITLE
[VEUE-655] Consistent Ratios for Video Cards

### DIFF
--- a/app/helpers/videos_helper.rb
+++ b/app/helpers/videos_helper.rb
@@ -8,7 +8,7 @@ module VideosHelper
   end
 
   def video_card_image_url(video)
-    video.primary_shot.attached? ? video.primary_shot.variant(resize_to_limit: [500, 500]) : video.thumbnail_url
+    video.primary_shot.attached? ? video.primary_shot.variant(resize_to_fill: [350, 221]) : video.thumbnail_url
   end
 
   def video_link_path(video)

--- a/app/views/shared/_video_card.html.haml
+++ b/app/views/shared/_video_card.html.haml
@@ -20,7 +20,7 @@
           = video.video_views.count
       .video-card__image__secondary
         - if video.secondary_shot.attached?
-          = image_tag video.secondary_shot.variant(resize_to_limit: [100, 100]), draggable: "false"
+          = image_tag video.secondary_shot.variant(resize_to_fill: [76, 61]), draggable: "false"
   .video-card__below
     .video-card__below__picture
       - channel = video.channel


### PR DESCRIPTION
We now use 'resize_to_fill' instead of limit or fit.... which means that the thumbnails are now consistent!

These are now the right size:

![image](https://user-images.githubusercontent.com/111/112198753-d017f480-8be3-11eb-9b22-70dab7e1f092.png)
