### PR TITLE
[VEUE-656]: Update mimemagic version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)


### PR DESCRIPTION
- Due to GPL issues, mimemagic must be update to >= 0.3.6