### PR TITLE
[VEUE-647] downcase channel_id to show channel page

### DIFF
--- a/app/controllers/channels/video_snapshots_controller.rb
+++ b/app/controllers/channels/video_snapshots_controller.rb
@@ -2,6 +2,8 @@
 
 module Channels
   class VideoSnapshotsController < ApplicationController
+    include ChannelConcern
+
     def index
       authorize!(:manage, current_video)
     end

--- a/app/controllers/channels/videos_controller.rb
+++ b/app/controllers/channels/videos_controller.rb
@@ -2,6 +2,8 @@
 
 module Channels
   class VideosController < ApplicationController
+    include ChannelConcern
+
     # GET /videos/1
     def show
       authorize!(:read, current_video)

--- a/app/controllers/concerns/channel_concern.rb
+++ b/app/controllers/concerns/channel_concern.rb
@@ -4,6 +4,8 @@ module ChannelConcern
   extend ActiveSupport::Concern
 
   included do
+    before_action :downcase_channel_id
+
     def current_channel
       @current_channel ||= Channel.friendly.find(params[:channel_id])&.decorate
     end
@@ -13,5 +15,9 @@ module ChannelConcern
       @current_video ||= current_channel.active_video&.decorate
     end
     helper_method :current_video
+
+    def downcase_channel_id
+      params[:channel_id] = params[:channel_id].downcase if params[:channel_id].present?
+    end
   end
 end

--- a/spec/system/channel_spec.rb
+++ b/spec/system/channel_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe "channel behaviour" do
       expect_meta_tag("og:description", channel.about)
     end
 
+    it "should load channel show with uppercase slug too" do
+      do_not_translate
+      visit(channel.slug.upcase)
+
+      expect_meta_tag("twitter:title", "channels.twitter.title")
+      expect_meta_tag("og:title", "channels.og.title")
+      assert_title "channels.seo.title"
+
+      # The descriptions should their about
+      expect_meta_tag("twitter:description", channel.about)
+      expect_meta_tag("og:description", channel.about)
+    end
+
     pending "test images in meta tag"
   end
 


### PR DESCRIPTION
### PR Functionality

This PR adds the ability to load channel pages even with capitalised/camelized slugs.