### PR TITLE
[VEUE-662]: Swap as many model specs to build_stubbed

### DIFF
--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -21,22 +21,18 @@ RSpec.describe Follow, type: :model do
     create(:follow, user: user, channel: channel_one)
 
     # Have to reload channel_one or it doesnt propagate the new follow
-    channel_one.reload
-
-    expect(channel_one.followers).to include(user)
+    expect(channel_one.reload.followers).to include(user)
   end
 
   it "Can follow multiple channels" do
     expect(channel_two.followers).to_not include(user)
 
     create(:follow, user: user, channel: channel_two)
-    channel_two.reload
-
-    expect(channel_two.followers).to include(user)
+    expect(channel_two.reload.followers).to include(user)
   end
 
   it "should prevent user from following themselves" do
-    follow = build(:follow, user: channel_one.user, channel: channel_one)
+    follow = build_stubbed(:follow, user: channel_one.user, channel: channel_one)
     expect(follow).to be_invalid
     expect(follow.errors.full_messages.join("\n")).to include("You can't follow yourself")
   end

--- a/spec/models/moderation_item_spec.rb
+++ b/spec/models/moderation_item_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ModerationItem do
     end
 
     it "should not call the perspective api when not enabled" do
-      moderation_item = build(:moderation_item)
+      moderation_item = build_stubbed(:moderation_item)
       moderation_item.fetch_scores!
       expect(moderation_item.summary_score).to eq(-1)
       expect(moderation_item.scores).to eq({})
@@ -18,7 +18,7 @@ RSpec.describe ModerationItem do
 
   describe "API Enabled" do
     it "should return the mocked passing value" do
-      item = build(:moderation_item)
+      item = build_stubbed(:moderation_item)
       item.fetch_scores!
       expect(item.summary_score).to eq(0.1982)
       expect(item).to be_approved
@@ -26,7 +26,7 @@ RSpec.describe ModerationItem do
 
     it "should error on the error key" do
       PerspectiveApi.key = "ERROR"
-      item = build(:moderation_item)
+      item = build_stubbed(:moderation_item)
       item.fetch_scores!
       expect(item.summary_score).to eq(-1)
       expect(item).to be_approved
@@ -35,7 +35,7 @@ RSpec.describe ModerationItem do
     it "should fail on the failure!" do
       # Must happen before setting the key otherwise it raises an error trying
       # to create the user
-      item = build(:moderation_item)
+      item = build_stubbed(:moderation_item)
       PerspectiveApi.key = "FAIL"
       item.fetch_scores!
       expect(item.summary_score).to be > 0.5

--- a/spec/models/mux_live_stream_spec.rb
+++ b/spec/models/mux_live_stream_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MuxRuby::LiveStream, type: :model do
     before do
       @mux_service = double(MUX_SERVICE)
       stub_const("MUX_SERVICE", @mux_service)
-      @user = create(:user)
+      @user = build_stubbed(:user)
     end
 
     it "should be able to #setup_as_streamer!" do

--- a/spec/models/pin_spec.rb
+++ b/spec/models/pin_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Pin, type: :model do
-  let(:video) { create(:live_video) }
+  let(:video) { build_stubbed(:live_video) }
   it "should be created from a URL and a name" do
     pin = Pin.process_create(
       video,

--- a/spec/models/session_token_spec.rb
+++ b/spec/models/session_token_spec.rb
@@ -15,27 +15,27 @@ RSpec.describe SessionToken, type: :model do
 
     it "should validate the phone number" do
       %w[Abc 1235 23427309784329087230497823908743208724309].each do |bad_number|
-        ula = SessionToken.new(phone_number: bad_number)
+        ula = build_stubbed(:session_token, phone_number: bad_number)
         expect(ula).to_not be_valid
         expect(ula.errors["phone_number"]).to_not be_empty
       end
 
       ["+19043840459", "+44 7911 123456"].each do |valid_number|
-        ula = SessionToken.new(phone_number: valid_number)
+        ula = build_stubbed(:session_token, phone_number: valid_number)
         expect(ula).to be_valid
         expect(ula.errors["phone_number"]).to be_empty
       end
     end
 
     it "should normalize the phone number" do
-      ula = SessionToken.create!(phone_number: "+1 (904) 384-0459")
+      ula = create(:session_token, phone_number: "+1 (904) 384-0459")
       expect(ula.phone_number).to eq("+19043840459")
     end
   end
 
   context "no user account" do
     it "should fail with a bad code" do
-      ula = SessionToken.create!(phone_number: "+19043840459")
+      ula = create(:session_token, phone_number: "+19043840459")
       expect(ula).to be_valid
 
       perform_enqueued_jobs


### PR DESCRIPTION
- Originally this was intended to go through the whole test suite and use `build_stubbed` , but we run a ton of callbacks and have tight coupling with our callbacks making `build_stubbed` fairly non-viable for us.

- `build_stubbed` works by creating a stubbed model that never touches the database resulting in faster specs.
- This changes as many model specs as possible to `build_stubbed` without breaking the test suite.