### PR TITLE
[VEUE-603]: Add video image previews in VODs

### DIFF
--- a/app/controllers/channels/video_snapshots_controller.rb
+++ b/app/controllers/channels/video_snapshots_controller.rb
@@ -22,6 +22,15 @@ module Channels
       render(json: {success: true})
     end
 
+    def show
+      return unless params[:format] == "jpg"
+
+      timecode = Integer(params[:timecode])
+      @current_snapshot = current_video.video_snapshots.find_at_timecode(timecode)
+
+      redirect_to(@current_snapshot.preview_url) if @current_snapshot
+    end
+
     def update
       authorize!(:manage, current_snapshot)
 

--- a/app/javascript/controllers/audience/player_controls_controller.ts
+++ b/app/javascript/controllers/audience/player_controls_controller.ts
@@ -5,17 +5,23 @@ import { VideoSeekEvent } from "helpers/video_helpers";
 export default class extends BaseController {
   static targets = [
     "video",
+    "videoPreviewContainer",
+    "videoPreviewImage",
     "audienceView",
     "progressBar",
     "progressBarContainer",
     "progressBarButton",
     "timeDuration",
     "timeDisplay",
+    "timePreview",
   ];
 
   readonly videoTarget!: HTMLVideoElement;
+  readonly videoPreviewImageTarget!: HTMLImageElement;
+  readonly videoPreviewContainerTarget!: HTMLDivElement;
   readonly timeDurationTarget!: HTMLElement;
   readonly timeDisplayTarget!: HTMLElement;
+  readonly timePreviewTarget!: HTMLDivElement;
   readonly audienceViewTarget!: HTMLElement;
   readonly progressBarTarget!: HTMLElement;
   readonly progressBarContainerTarget!: HTMLElement;
@@ -69,18 +75,20 @@ export default class extends BaseController {
     event.preventDefault();
 
     this.pointerIsDown = true;
-    this.handlePointerLocation(event);
+    this.updateVideoTime(event);
   }
 
   handlePointerMove(event: PointerEvent): void {
     event.preventDefault();
+
+    this.displayPreview(event);
 
     // The pointer has to be down for us to register a pointermove
     if (this.pointerIsDown !== true) {
       return;
     }
 
-    this.handlePointerLocation(event);
+    this.updateVideoTime(event);
   }
 
   handlePointerUp(): void {
@@ -105,6 +113,39 @@ export default class extends BaseController {
       });
   }
 
+  handlePointerEnter(event: PointerEvent): void {
+    event.preventDefault();
+
+    this.displayPreview(event);
+  }
+
+  handlePointerLeave(event: PointerEvent): void {
+    event.preventDefault();
+
+    this.timePreviewTarget.style.display = "none";
+    this.videoPreviewContainerTarget.style.display = "none";
+  }
+
+  displayPreview(event: PointerEvent): void {
+    event.preventDefault();
+
+    const currentTime = this.getPointerLocationTime(event);
+
+    if (currentTime == null || currentTime < -1 || isNaN(currentTime)) {
+      return;
+    }
+
+    this.displayTimeAndVideoPreviews(event, currentTime);
+
+    const timecode = Math.floor(currentTime / 30);
+
+    if (timecode >= 0) {
+      this.videoPreviewImageTarget.src = `${window.location.pathname}/snapshots/${timecode}.jpg`;
+    }
+
+    this.videoPreviewImageTarget.style.display = "block";
+  }
+
   handlePointerLocation(event: PointerEvent): void {
     const frameRect = this.progressBarContainerTarget.getBoundingClientRect();
 
@@ -122,6 +163,45 @@ export default class extends BaseController {
       detail: { timecodeMs: currentTime },
     });
     this.videoTarget.dispatchEvent(evt);
+  }
+
+  updateVideoTime(event: PointerEvent): void {
+    const currentTime = this.getPointerLocationTime(event);
+    this.timeDisplayTarget.innerHTML = displayTime(currentTime);
+    this.videoTarget.currentTime = currentTime;
+    this.handleTimeUpdate();
+  }
+
+  getPointerLocationTime(event: PointerEvent): number {
+    const frameRect = this.progressBarContainerTarget.getBoundingClientRect();
+
+    // find the offset of the progressbar and the actual X location of the event
+    const x = event.clientX - frameRect.left;
+    const pos = x / frameRect.width;
+    return pos * this.duration;
+  }
+
+  private displayTimeAndVideoPreviews(
+    event: PointerEvent,
+    currentTime: number
+  ): void {
+    const containerOffset = this.progressBarContainerTarget.getBoundingClientRect()
+      .x;
+    const timePreviewOffset =
+      this.timePreviewTarget.getBoundingClientRect().width / 2;
+
+    const x = event.clientX - containerOffset;
+    const timePreviewX = x - timePreviewOffset;
+    this.timePreviewTarget.style.transform = `translate(${timePreviewX}px, -100%)`;
+    this.timePreviewTarget.innerText = displayTime(currentTime);
+    this.timePreviewTarget.style.display = "block";
+
+    const videoPreviewOffset =
+      this.videoPreviewContainerTarget.getBoundingClientRect().width / 2;
+    const videoPreviewX = x - videoPreviewOffset;
+
+    this.videoPreviewContainerTarget.style.transform = `translate(${videoPreviewX}px, -100%)`;
+    this.videoPreviewContainerTarget.style.display = "block";
   }
 
   set videoState(state: string) {

--- a/app/javascript/controllers/broadcast_controller.ts
+++ b/app/javascript/controllers/broadcast_controller.ts
@@ -183,10 +183,11 @@ export default class extends Controller {
 
     await Promise.all(
       snapshots.map(async (snapshot) => {
-        const { image, deviceType, deviceId } = snapshot;
+        const { image, deviceType, deviceId, priority } = snapshot;
         const data = {
           timecode,
           image,
+          priority,
           device_type: deviceType,
           device_id: deviceId,
         };

--- a/app/javascript/helpers/broadcast/mixers/video_mixer.ts
+++ b/app/javascript/helpers/broadcast/mixers/video_mixer.ts
@@ -11,6 +11,7 @@ export const BroadcastLayoutChangedEvent = "BroadcastLayoutChanged";
 interface VideoShot {
   deviceId: string;
   deviceType: string;
+  priority: number;
   image: Blob;
 }
 
@@ -114,6 +115,7 @@ export default class VideoMixer implements Mixer {
       this.captureSources.map(async (source) => {
         const image = await source.captureImage();
         return {
+          priority: source.layout.priority,
           deviceId: source.deviceId,
           deviceType: source.videoSourceType,
           image,

--- a/app/javascript/style/video/_player_controls.scss
+++ b/app/javascript/style/video/_player_controls.scss
@@ -90,6 +90,7 @@
 
     .progress-bar-container {
       cursor: pointer;
+      position: relative;
       display: none;
       align-items: center;
       background: color.$neutral-middle;
@@ -116,6 +117,47 @@
       margin-left: -8px;
       background: color.$white;
       box-shadow: color.$box-shadow;
+    }
+
+    .progress-bar__video-preview,
+    .progress-bar__time-preview {
+      // layout
+      position: absolute;
+      z-index: z_index.$video-controls;
+
+      // style
+      opacity: 0.9;
+      border-radius: 10px;
+    }
+
+    .progress-bar__time-preview {
+      // layout
+      padding: 0.2rem 0.4rem;
+
+      // style
+      background: rgba(0, 0, 0, 0.7);
+      color: white;
+    }
+
+    .progress-bar__video-preview {
+      position: absolute;
+
+      box-shadow: color.$box-shadow;
+
+      // Assumed 16:9 ratio, has to be a fixed h/w since its absolutely positioned.
+      height: 112px;
+      width: 200px;
+      border-radius: 10px;
+      background: rgba(0, 0, 0, 0.25);
+
+      &__image {
+        position: absolute;
+        height: 100%;
+        width: 100%;
+        top: 0;
+        object-fit: fill;
+        border-radius: 10px;
+      }
     }
 
     .progress-background {
@@ -205,6 +247,12 @@
     .toggle-play.desktop {
       display: flex;
       margin: 0 0.2rem;
+    }
+
+    .player-controls {
+      .progress-bar__time-preview {
+        padding: 1rem 0.75rem;
+      }
     }
   }
 }

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,7 +5,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    can(:read, [Channel, User])
+    can(:read, [Channel, User, VideoSnapshot])
     can(:read, Video, visibility: %w[public protected])
 
     return if user.blank?

--- a/app/models/video_snapshot.rb
+++ b/app/models/video_snapshot.rb
@@ -4,4 +4,29 @@ class VideoSnapshot < ApplicationRecord
   belongs_to :video
 
   has_one_attached :image
+
+  scope :future_snapshots, ->(timecode) { where("timecode >= ?", timecode) }
+  scope :past_snapshots, ->(timecode) { where("timecode < ?", timecode) }
+  scope :priority, ->(number) { where(priority: number) }
+
+  def self.find_all_between(min:, max:)
+    future_snapshots(min)
+      .past_snapshots(max)
+      .order(timecode: :asc, priority: :asc)
+  end
+
+  # Give a half second buffer for screenshots (30_000 is actual interval)
+  # This is used for positive look ahead and negative look behind
+  def self.find_at_timecode(timecode, interval: 29_500)
+    # Timecodes are given as 1, 2, 3, etc
+    timecode *= 30_000
+
+    min = timecode - interval
+    max = timecode + interval
+    find_all_between(min: min, max: max).first
+  end
+
+  def preview_url
+    Router.url_for(image.variant(resize_to_limit: [200, 112]))
+  end
 end

--- a/app/views/channels/videos/partials/_player_controls.html.haml
+++ b/app/views/channels/videos/partials/_player_controls.html.haml
@@ -10,8 +10,14 @@
       target: "audience--player-controls.progressBarContainer",
       action: "pointerdown->audience--player-controls#handlePointerDown
                pointerup->audience--player-controls#handlePointerUp
-               pointermove->audience--player-controls#handlePointerMove"
+               pointermove->audience--player-controls#handlePointerMove
+               pointerenter->audience--player-controls#handlePointerEnter
+               pointerleave->audience--player-controls#handlePointerLeave"
     }}
+    .progress-bar__time-preview{style: "display: none;", data: { target: "audience--player-controls.timePreview"}}
+    .progress-bar__video-preview{style: "display: none;", data: { target: "audience--player-controls.videoPreviewContainer" }}
+      %img.progress-bar__video-preview__image{data: { target: "audience--player-controls.videoPreviewImage" }}
+
     %span.progress-bar{
       data: { target: "audience--player-controls.progressBar", currentTime: "0", duration: "0" }
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,7 +96,8 @@ Rails.application.routes.draw do
         resources :events, only: %i[show index]
       end
 
-      resources :video_snapshots, path: "snapshots", only: %i[create show index update]
+      resources :video_snapshots, path: "snapshots", only: %i[create index update]
+      get 'snapshots/:timecode', to: 'video_snapshots#show'
     end
 
     # These are the routes related to the "Streamers" profile page

--- a/db/migrate/20210406205818_add_priority_to_video_snapshots.rb
+++ b/db/migrate/20210406205818_add_priority_to_video_snapshots.rb
@@ -1,0 +1,5 @@
+class AddPriorityToVideoSnapshots < ActiveRecord::Migration[6.1]
+  def change
+    add_column(:video_snapshots, :priority, :integer)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_04_07_074432) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -222,6 +221,7 @@ ActiveRecord::Schema.define(version: 2021_04_07_074432) do
     t.string "device_type"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "priority"
     t.index ["video_id"], name: "index_video_snapshots_on_video_id"
   end
 

--- a/spec/factories/video_snapshots.rb
+++ b/spec/factories/video_snapshots.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     viewer_count { Faker::Number.within(range: 1..100_000) }
     device_id { SecureRandom.uuid }
     device_type { %w[screen camera].sample }
+    priority { 1 }
   end
 end

--- a/spec/requests/video_snapshots_request_spec.rb
+++ b/spec/requests/video_snapshots_request_spec.rb
@@ -67,4 +67,33 @@ RSpec.describe "VideoSnapshots", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "GET /snapshots.png?t=timecode" do
+    let(:video) { create(:vod_video) }
+    let(:headers) { {ACCEPT: "image/jpeg"} }
+
+    it "returns the snapshot at 0 seconds if the timecode is 0" do
+      snapshot_one = create(:video_snapshot, video: video, timecode: 0)
+      create(:video_snapshot, video: video, timecode: 31_000)
+
+      expect(get("#{channel_video_video_snapshot_path(video.channel, video, '0')}.jpg"))
+        .to redirect_to(snapshot_one.preview_url)
+    end
+
+    it "returns the snapshot at 30 seconds if the timecode is 1" do
+      create(:video_snapshot, video: video, timecode: 0)
+      snapshot_two = create(:video_snapshot, video: video, timecode: 30_000)
+
+      expect(get("#{channel_video_video_snapshot_path(video.channel, video, '1')}.jpg"))
+        .to redirect_to(snapshot_two.preview_url)
+    end
+
+    it "returns the snapshot at 60 seconds if the timecode is 3" do
+      create(:video_snapshot, video: video, timecode: 30_000)
+      snapshot_two = create(:video_snapshot, video: video, timecode: 60_000)
+
+      expect(get("#{channel_video_video_snapshot_path(video.channel, video, '2')}.jpg"))
+        .to redirect_to(snapshot_two.preview_url)
+    end
+  end
 end

--- a/spec/system/vod/scrubber_previews_spec.rb
+++ b/spec/system/vod/scrubber_previews_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+describe "Scrubber previews" do
+  let(:video) { create(:vod_video) }
+
+  before(:each) do
+    driven_by :media_browser
+    visit path_for_video(video)
+  end
+
+  describe "With snapshots" do
+    # All need to be eagerly created to be able to show on hover
+    let!(:snapshot_one) { create(:video_snapshot, video: video, timecode: 0) }
+    let!(:snapshot_two) { create(:video_snapshot, video: video, timecode: 30_000) }
+    let!(:snapshot_three) { create(:video_snapshot, video: video, timecode: 60_000) }
+
+    it "Should show a video preview on mouse hover" do
+      find(".progress-bar-container").hover
+
+      # first paint can be slow in testing, give it a little extra wait time
+      expect(page).to have_css(".progress-bar__time-preview")
+      expect(page).to have_css(".progress-bar__video-preview")
+
+      # We have to rehover to redisplay the image
+      find(".progress-bar-container").hover
+
+      # Make sure the image has the id of snapshot 0, this takes a while, add an extra wait
+      expect(page).to have_css(
+        ".progress-bar__video-preview__image[src*='/#{video.channel.slug}/videos/#{video.id}/snapshots/0.jpg'", wait: 5
+      )
+    end
+
+    it "Should show the next snapshot at ~ 30 seconds" do
+      # This is super finnicky and totally dependent on the video and viewport size,
+      # so take care if the test video changes!
+      script = <<~JS
+        const container = document.querySelector(".progress-bar-container")
+        const { width, x, y } = container.getBoundingClientRect()
+        // Approximate guess of 30 seconds
+        const offset = (width / 2) + 100
+        container.dispatchEvent(new PointerEvent("pointerenter", {clientX: x + offset, clientY: y, view: window}))
+      JS
+
+      execute_script(script)
+
+      expect(page).to have_css(".progress-bar__time-preview")
+      expect(page).to have_css(".progress-bar__video-preview")
+
+      # We have to re-execute the script to get it to re-hover
+      execute_script(script)
+
+      query = ".progress-bar__video-preview__image[src*='/#{video.channel.slug}/videos/#{video.id}/snapshots/1.jpg'"
+      # Make sure the image has the timecode of 1
+      expect(page).to have_css(query)
+    end
+  end
+
+  describe "Without snapshots" do
+    it "Should show a blank preview with no images" do
+      find(".progress-bar-container").hover
+
+      # Preview time and image container should still show
+      expect(page).to have_css(".progress-bar__time-preview")
+      expect(page).to have_css(".progress-bar__video-preview")
+
+      expect(find(".progress-bar__video-preview__image")).to be_visible
+    end
+  end
+end


### PR DESCRIPTION
- Adds a `/snapshots/:timecode.jpg` route to snapshots
- Adds VOD and image previews
- Will display a blank image until the real image is fetched
- Adds many tests around this

## Examples
<img width="850" alt="Screen Shot 2021-04-02 at 11 48 40 AM" src="https://user-images.githubusercontent.com/26425882/113461879-72a65380-93ec-11eb-8b50-81e57c22c770.png">
<img width="692" alt="Screen Shot 2021-04-02 at 7 47 59 PM" src="https://user-images.githubusercontent.com/26425882/113461863-60c4b080-93ec-11eb-88d4-b1c438165e2d.png">
<img width="434" alt="Screen Shot 2021-04-02 at 7 47 00 PM" src="https://user-images.githubusercontent.com/26425882/113461868-64583780-93ec-11eb-99f0-f8c4839b137e.png">


@hcatlin there is no preloading or cache headers (although locally, the images were returning a 304 request not modified) perhaps you could help guide on how that should be done?