### PR TITLE
[VEUE-669] fix button margin in header

### DIFF
--- a/app/javascript/style/components/_header.scss
+++ b/app/javascript/style/components/_header.scss
@@ -51,6 +51,7 @@ header {
       font-family: font.$poppins;
       font-weight: 500;
       font-size: 14px;
+      margin: 0;
 
       @include large() {
         height: 34px;


### PR DESCRIPTION
Fix for having a margin on `Login` button horizontally in header.