### PR TITLE
[VEUE-617] Fixing border on Streame's messages

### DIFF
--- a/app/javascript/style/components/_message.scss
+++ b/app/javascript/style/components/_message.scss
@@ -77,6 +77,7 @@
 
       .message--announcement & {
         background: color.$red-highlight;
+        border: 1px solid color.$red-highlight;
         color: color.$white;
       }
 


### PR DESCRIPTION
Previously the streamers message had a subtle grey border, but this isn't supposed to be there, so instead we make it red so it stays the right size

![image](https://user-images.githubusercontent.com/111/114062787-e8377700-9865-11eb-96f9-7880f5cc3f20.png)
