### PR TITLE
[VEUE-700] Remove Stale Scheduled Videos

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -49,7 +49,7 @@ class Video < ApplicationRecord
 
   scope :stale,
         -> {
-          pending.where("updated_at < ?", 30.minutes.ago)
+          pending.where("updated_at <= ?", 30.minutes.ago).or(scheduled.where("scheduled_at <= ?", 1.hour.ago))
         }
 
   scope :most_recent,


### PR DESCRIPTION
Here, we hook into the logic that the cron endpoint already uses, and just expand the definition of a ‘stale’ video to include those taht are scheduled and an hour past their time.