### PR TITLE
[VEUE-705]: Remove media query making scrubbers look terrible

### DIFF
--- a/app/javascript/style/video/_player_controls.scss
+++ b/app/javascript/style/video/_player_controls.scss
@@ -248,11 +248,5 @@
       display: flex;
       margin: 0 0.2rem;
     }
-
-    .player-controls {
-      .progress-bar__time-preview {
-        padding: 1rem 0.75rem;
-      }
-    }
   }
 }


### PR DESCRIPTION
- On larger screens the scrubber looked horrible. This fixes that.

## Before
<img width="180" alt="Screen Shot 2021-04-12 at 2 24 40 PM" src="https://user-images.githubusercontent.com/26425882/114443864-34ebbc80-9b9c-11eb-82c4-ee54b59ef605.png">

## After

<img width="248" alt="Screen Shot 2021-04-12 at 2 29 28 PM" src="https://user-images.githubusercontent.com/26425882/114443899-3f0dbb00-9b9c-11eb-9d06-646fdc71a23d.png">
