### PR TITLE
[VEUE-710]: Ensure end_reason and durations are added to videos

### DIFF
--- a/app/lib/phenix.rb
+++ b/app/lib/phenix.rb
@@ -141,9 +141,7 @@ module Phenix
       when "starting"
         video.start! unless video.live?
       when "ended"
-        video.duration = payload[:data][:duration] / 1_000
-        video.end_reason = payload[:data][:reason]
-        video.end! if video.may_end?
+        ended_payload(video, payload)
       when "on-demand"
         on_demand_payload(video, payload)
       else
@@ -164,7 +162,7 @@ module Phenix
                           end
 
       Faraday.post(
-        Rails.application.routes.url_helpers.phenix_url(host: webhook_host, port: nil, protocol: "https"),
+        Router.phenix_url(host: webhook_host, port: nil, protocol: "https"),
         payload.to_json,
         "Content-Type": "application/json",
       )
@@ -180,6 +178,21 @@ module Phenix
 
       # We can do VOD now!
       video.finish!
+    end
+
+    def self.ended_payload(video, payload)
+      # durations are provided in milliseconds
+      # https://phenixrts.com/docs/api/#stream-ended-notification
+      duration = payload.dig(:data, :duration)
+      end_reason = payload.dig(:data, :reason)
+
+      attrs = {}
+      attrs[:duration] = (duration / 1_000).ceil if duration
+      attrs[:end_reason] = end_reason if end_reason
+
+      video.update!(attrs)
+
+      video.end! if video.may_end?
     end
 
     def self.find_tag(payload, tag_name)

--- a/spec/lib/phenix_spec.rb
+++ b/spec/lib/phenix_spec.rb
@@ -43,6 +43,7 @@ describe Phenix do
           data: {
             tags: %W[webhookHost:sushitown.com videoId:#{video.id}],
             duration: 5000,
+            reason: "video stopped",
             uri: "vod.m3u8",
           },
         },
@@ -50,6 +51,26 @@ describe Phenix do
       video.reload
 
       expect(video.duration).to eq(5)
+      expect(video.end_reason).to eq("video stopped")
+      expect(video).to be_ended
+
+      # Sometimes the end request gets sent twice. Lets handle null durations and end_reasons
+      Phenix::Webhooks.process(
+        {
+          what: "ended",
+          data: {
+            tags: %W[webhookHost:sushitown.com videoId:#{video.id}],
+            reason: nil,
+            duration: nil,
+            uri: "vod.m3u8",
+          },
+        },
+      )
+
+      video.reload
+
+      expect(video.duration).to eq(5)
+      expect(video.end_reason).to eq("video stopped")
       expect(video).to be_ended
     end
 

--- a/spec/requests/internal/webhooks_request_spec.rb
+++ b/spec/requests/internal/webhooks_request_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Internal::WebhooksController do
+  describe "ending a video" do
+    let(:video) { create(:live_video) }
+    let(:duration) { 1337.894 }
+    let(:end_reason) { "video stopped" }
+    let(:end_payload) {
+      {
+        what: "ended",
+        data: {
+          tags: %W[webhookHost:sushitown.com videoId:#{video.id}],
+          reason: end_reason,
+          duration: duration,
+          uri: "vod.m3u8",
+        },
+      }
+    }
+
+    it "should end a video" do
+      post "/_/_/phenix", as: :json, params: end_payload
+      expect(video.reload.duration).to eq((duration / 1_000).ceil)
+      expect(video.end_reason).to eq(end_reason)
+      expect(video).to be_ended
+    end
+
+    it "should handle nil durations and end_reasons gracefully" do
+      nil_payload = end_payload.deep_dup
+
+      nil_payload[:data][:duration] = nil
+      nil_payload[:data][:reason] = nil
+
+      # Lets check to make sure nothing happens with an initial nil_payload
+      post "/_/_/phenix", as: :json, params: nil_payload
+
+      expect(video.reload.duration).to be_nil
+      expect(video.end_reason).to be_nil
+      expect(video).to be_ended
+
+      # This is what we typically expect to happen
+      post "/_/_/phenix", as: :json, params: end_payload
+
+      expect(video.reload.duration).to eq((duration / 1_000).ceil)
+      expect(video.end_reason).to eq(end_reason)
+      expect(video).to be_ended
+
+      # Should not update the video durations and end_reasons with a nil payload
+      post "/_/_/phenix", as: :json, params: nil_payload
+
+      expect(video.reload.duration).to eq((duration / 1_000).ceil)
+      expect(video.end_reason).to eq(end_reason)
+      expect(video).to be_ended
+    end
+  end
+end


### PR DESCRIPTION
- Does a nil check for `durations` and `end_reasons` to make sure we dont overwrite a good `duration` / `end_reason`.
- Adds some model tests around the end webhook