### PR TITLE
[VEUE-702]: Justify view counts in the center

### DIFF
--- a/app/javascript/style/components/_video_card.scss
+++ b/app/javascript/style/components/_video_card.scss
@@ -108,6 +108,7 @@
       bottom: 10px;
       margin-left: 10px;
       align-items: center;
+      justify-content: center;
     }
     &__svg {
       margin: auto 0 auto 10px;


### PR DESCRIPTION
## Before

<img width="95" alt="Screen Shot 2021-04-19 at 5 30 56 PM" src="https://user-images.githubusercontent.com/26425882/115305913-1144eb00-a135-11eb-805c-3d8bc8f1ea1a.png">

## After

<img width="91" alt="Screen Shot 2021-04-19 at 5 31 06 PM" src="https://user-images.githubusercontent.com/26425882/115305925-186bf900-a135-11eb-9daa-7861b54488a3.png">

