### PR TITLE
[VEUE-734]: Fix streamer profile area on firefox

### DIFF
--- a/app/javascript/style/video/_streamer_profile.scss
+++ b/app/javascript/style/video/_streamer_profile.scss
@@ -19,7 +19,7 @@
     z-index: z_index.$streamer-profile;
     top: 0px;
     overflow: hidden;
-    width: -webkit-fill-available;
+    width: fill-available;
     animation: toZeroTop ease 0.3s;
 
     @include smallTall() {


### PR DESCRIPTION
- Fixes streamer profile area on firefox by changing the from using a webkit vendor prefix to the regular `fill-available` and letting `autoprefixer` fix it for us.

## Before

<img width="1433" alt="Screen Shot 2021-04-20 at 11 59 42 AM" src="https://user-images.githubusercontent.com/26425882/115429357-561e5f80-a1d1-11eb-860b-72503583a5c8.png">

## After

<img width="1440" alt="Screen Shot 2021-04-20 at 12 10 26 PM" src="https://user-images.githubusercontent.com/26425882/115429459-6afaf300-a1d1-11eb-9b90-5cd08f15c348.png">
