### PR TITLE
[VEUE-745] Webcam Permissions Not Prompted

### DIFF
--- a/app/javascript/helpers/broadcast/capture_sources/webcam.ts
+++ b/app/javascript/helpers/broadcast/capture_sources/webcam.ts
@@ -49,8 +49,8 @@ export class WebcamCaptureSource extends VideoCaptureSource {
     this.mediaStream = await navigator.mediaDevices.getUserMedia({
       video: {
         deviceId: this.deviceId || "default",
-        height: capabilities.height.max,
-        width: capabilities.width.max,
+        height: 1440,
+        width: 1080,
       },
       audio: false,
     });


### PR DESCRIPTION
When you have yet to give access to your camera to the Browser– the “Capabilities” list of getEnumeratedDevices is empty…. this was causing us to fail finding “max” for the width and height and therefore never prompting for access.

Instead, here I’m specifically asking for a size– the browser will get as close as it can… which is fine with us.

Unfortunately, this isn’t possible to test :/ It’s either “yes” or “never” for cameras.