### PR TITLE
[Veue 748]: Fix how initial snapshots are captured

### DIFF
--- a/app/controllers/channels/video_snapshots_controller.rb
+++ b/app/controllers/channels/video_snapshots_controller.rb
@@ -13,11 +13,7 @@ module Channels
 
       snapshot = VideoSnapshot.create!(snapshot_params.except(:channel_id))
 
-      if !current_video.primary_shot.attached?
-        attach_primary_shot(snapshot)
-      elsif !current_video.secondary_shot.attached?
-        attach_secondary_shot(snapshot)
-      end
+      current_video.attach_initial_shot!(snapshot)
 
       render(json: {success: true})
     end
@@ -34,8 +30,8 @@ module Channels
     def update
       authorize!(:manage, current_snapshot)
 
-      attach_primary_shot(current_snapshot) if params[:commit] == "primary"
-      attach_secondary_shot(current_snapshot) if params[:commit] == "secondary"
+      current_video.attach_primary_shot!(current_snapshot) if params[:commit] == "primary"
+      current_video.attach_secondary_shot!(current_snapshot) if params[:commit] == "secondary"
 
       render(action: "index", layout: false)
     end
@@ -58,15 +54,7 @@ module Channels
     private
 
     def snapshot_params
-      params.permit(:timecode, :image, :device_type, :device_id, :video_id, :channel_id)
-    end
-
-    def attach_primary_shot(snapshot)
-      current_video.primary_shot.attach(snapshot.image.blob)
-    end
-
-    def attach_secondary_shot(snapshot)
-      current_video.secondary_shot.attach(snapshot.image.blob)
+      params.permit(:timecode, :image, :device_type, :device_id, :priority, :video_id, :channel_id)
     end
   end
 end

--- a/app/javascript/controllers/chat/send_message_controller.ts
+++ b/app/javascript/controllers/chat/send_message_controller.ts
@@ -105,6 +105,11 @@ export default class extends Controller {
   }
 
   showLinkShareIcon(): void {
+    // dont show in broadcaster!
+    if (document.querySelector("#broadcast")) {
+      return;
+    }
+
     this.linkShareTarget.style.display = "flex";
   }
 

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -140,6 +140,19 @@ class Video < ApplicationRecord
     end
   end
 
+  def attach_primary_shot!(snapshot)
+    primary_shot.attach(snapshot.image.blob)
+  end
+
+  def attach_secondary_shot!(snapshot)
+    secondary_shot.attach(snapshot.image.blob)
+  end
+
+  def attach_initial_shot!(snapshot)
+    attach_primary_shot!(snapshot) if snapshot.priority == 1
+    attach_secondary_shot!(snapshot) if snapshot.priority == 2
+  end
+
   private
 
   def after_go_live

--- a/app/models/video_snapshot.rb
+++ b/app/models/video_snapshot.rb
@@ -3,6 +3,9 @@
 class VideoSnapshot < ApplicationRecord
   belongs_to :video
 
+  validates :priority, numericality: {only_integer: true, greater_than_or_equal_to: 1}
+  validates :timecode, numericality: {only_integer: true, greater_than_or_equal_to: -1}
+
   has_one_attached :image
 
   scope :future_snapshots, ->(timecode) { where("timecode >= ?", timecode) }

--- a/app/views/channels/video_snapshots/_video_snapshot.html.haml
+++ b/app/views/channels/video_snapshots/_video_snapshot.html.haml
@@ -1,6 +1,6 @@
 - submit_form = "click->video-snapshots#submitForm keydown->video-snapshots#submitForm"
 - if video_snapshot.image.attached?
-  .video-snapshot
+  .video-snapshot{id: "#{dom_id(video_snapshot)}"}
     = image_tag video_snapshot.image, alt: "Video snapshot"
     = form_with model: video_snapshot, url: channel_video_video_snapshot_path(current_channel, current_video, video_snapshot), data: { controller: "video-snapshots" } do |form|
       = form.button "Set Primary", name: :commit, value: "primary",

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -123,4 +123,23 @@ RSpec.describe Video, type: :model do
       expect(video.end_reason).to eq(reason)
     end
   end
+
+  describe "Snapshots" do
+    let(:snapshot_one) { create(:video_snapshot, priority: 1) }
+    let(:snapshot_two) { create(:video_snapshot, priority: 2) }
+
+    it "Should attach priorty 1 snapshots as primary" do
+      video.attach_initial_shot!(snapshot_one)
+
+      expect(video.primary_shot.blob).to eq(snapshot_one.image.blob)
+      expect(video.secondary_shot.blob).to be_nil
+    end
+
+    it "Should only attach priority 2 snapshots as secondary" do
+      video.attach_initial_shot!(snapshot_two)
+
+      expect(video.secondary_shot.blob).to eq(snapshot_two.image.blob)
+      expect(video.primary_shot.blob).to be_nil
+    end
+  end
 end

--- a/spec/requests/video_snapshots_request_spec.rb
+++ b/spec/requests/video_snapshots_request_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "VideoSnapshots", type: :request do
            params: {
              image: image,
              timecode: 0,
+             priority: 1,
              device_id: SecureRandom.uuid,
              device_type: "screen",
            }
@@ -39,6 +40,7 @@ RSpec.describe "VideoSnapshots", type: :request do
              params: {
                image: image,
                timecode: 0,
+               priority: 1,
                device_id: SecureRandom.uuid,
                device_type: "screen",
              }

--- a/spec/system/vod/scrubber_previews_spec.rb
+++ b/spec/system/vod/scrubber_previews_spec.rb
@@ -8,8 +8,9 @@ describe "Scrubber previews" do
 
   before(:each) do
     driven_by :media_browser
+    resize_window_desktop
     visit path_for_video(video)
-    assert_video_is_playing
+    assert_video_is_playing(10)
     ensure_controls_visible
   end
 
@@ -42,7 +43,7 @@ describe "Scrubber previews" do
         const container = document.querySelector(".progress-bar-container")
         const { width, x, y } = container.getBoundingClientRect()
         // Approximate guess of 30 seconds
-        const offset = (width / 2) + 100
+        const offset = (width / 1.5)
         container.dispatchEvent(new PointerEvent("pointerenter", {clientX: x + offset, clientY: y, view: window}))
       JS
 
@@ -56,7 +57,7 @@ describe "Scrubber previews" do
 
       query = ".progress-bar__video-preview__image[src*='/#{video.channel.slug}/videos/#{video.id}/snapshots/1.jpg'"
       # Make sure the image has the timecode of 1
-      expect(page).to have_css(query)
+      expect(page).to have_css(query, wait: 10)
     end
   end
 

--- a/spec/system/vod/snapshots_spec.rb
+++ b/spec/system/vod/snapshots_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+describe "adding snapshots to videos" do
+  let(:video) { create(:vod_video) }
+  let!(:snapshot_one) { create(:video_snapshot, priority: 1, video: video) }
+  let!(:snapshot_two) { create(:video_snapshot, priority: 2, video: video) }
+  let(:snapshot_one_query) { "##{dom_id(snapshot_one)}" }
+  let(:snapshot_two_query) { "##{dom_id(snapshot_two)}" }
+
+  before(:each) do
+    resize_window_desktop
+    login_as(video.user)
+    visit(channel_video_video_snapshots_path(video.channel, video))
+  end
+
+  it "should allow you to set a priority 2 shot as priority 1 and vice versa" do
+    within(snapshot_one_query) do
+      click_button("Set Secondary")
+      expect(page).to have_button("Set Secondary", disabled: true)
+      expect(video.secondary_shot.blob).to eq(snapshot_one.image.blob)
+    end
+
+    within(snapshot_two_query) do
+      click_button("Set Primary")
+      expect(page).to have_button("Set Primary", disabled: true)
+      expect(video.primary_shot.blob).to eq(snapshot_two.image.blob)
+    end
+  end
+end


### PR DESCRIPTION
- Priority 1 is always the main thumbnail.
- Priority 2 is always the secondary thumbnail now.
- Adds validations around timecodes and priority for visibility should something go wrong
- Add an additional wait onto the image previews to help fix "flakiness"
- Add tests for snapshots
- Fix my broken link sharing nonsense.