### PR TITLE
[Veue 749]:  Faster snapshot previews...maybe?

### DIFF
--- a/app/controllers/channels/video_snapshots_controller.rb
+++ b/app/controllers/channels/video_snapshots_controller.rb
@@ -13,6 +13,9 @@ module Channels
 
       snapshot = VideoSnapshot.create!(snapshot_params.except(:channel_id))
 
+      # Preprocess the image so we can pull it from S3 in the future.
+      snapshot.processed_preview
+
       current_video.attach_initial_shot!(snapshot)
 
       render(json: {success: true})

--- a/app/javascript/controllers/audience/player_controls_controller.ts
+++ b/app/javascript/controllers/audience/player_controls_controller.ts
@@ -253,7 +253,6 @@ export default class extends BaseController {
       const img = new Image();
       img.src = `${urlPrefix}/${i}.jpg`;
       img.style.display = "none";
-      // document.body.appendChild(img);
     }
   }
 

--- a/app/models/video_snapshot.rb
+++ b/app/models/video_snapshot.rb
@@ -37,7 +37,18 @@ class VideoSnapshot < ApplicationRecord
     image.blob == video.secondary_shot.blob
   end
 
+  # Processed the image variant
+  def processed_preview
+    image.variant(resize_to_limit: [112, 200]).processed
+  end
+
   def preview_url
-    Router.url_for(image.variant(resize_to_limit: [200, 112]))
+    if Rails.application.config.active_storage.service == :amazon
+      # if using S3, use the S3 url directly
+      processed_preview.url
+    else
+      # this is for test / local envs.
+      Router.url_for(processed_preview)
+    end
   end
 end


### PR DESCRIPTION
- Uses the `.processed` check to see if the image has been processed and uses the processed version rather than resizing on the fly.
- Calls `.processed` when the image is created so as to have the resized version available when the video is created. (not sure this actually does anything)
- Adds a couple helpers and uses the processed url when possible and falls back to `url_for`

I have no idea if this is actually faster, but it seems like it should be faster!