### PR TITLE
[VEUE-797]: Fix issue with currentTime returning NaN

### DIFF
--- a/app/javascript/controllers/audience/player_controls_controller.ts
+++ b/app/javascript/controllers/audience/player_controls_controller.ts
@@ -393,8 +393,8 @@ export default class extends BaseController {
     event: PointerEvent,
     currentTime: number
   ): void {
-    const containerOffset = this.progressBarContainerTarget.getBoundingClientRect()
-      .x;
+    const containerOffset =
+      this.progressBarContainerTarget.getBoundingClientRect().x;
     const timePreviewOffset =
       this.timePreviewTarget.getBoundingClientRect().width / 2;
 


### PR DESCRIPTION
- Sometimes NaN was returning if the video hadnt fully loaded and the duration hadnt propagated. This _should_ fix this error.

https://appsignal.com/veue/sites/5f1b3af314ad66221c331630/exceptions/incidents/99?timestamp=2021-06-01T21%3A45%3A36Z