### PR TITLE
[VEUE-936]: Remove unnecessary z-index

### DIFF
--- a/app/javascript/style/components/_video_card.scss
+++ b/app/javascript/style/components/_video_card.scss
@@ -81,7 +81,6 @@ $min-width: 150px;
       position: absolute;
       top: 40%;
       left: 40%;
-      z-index: 1;
       > svg {
         background-color: color.$veue-corporate;
         border-radius: 10px;


### PR DESCRIPTION
- Remove unnecessary z-index on videos causing an overlap of our login header.

![Image from iOS](https://user-images.githubusercontent.com/26425882/121390682-9c638580-c91b-11eb-9c73-50402cbd616d.jpg)
