### PR TITLE
[VEUE-930]: Fix start offsets

### DIFF
--- a/app/javascript/controllers/audience/vod_video_controller.ts
+++ b/app/javascript/controllers/audience/vod_video_controller.ts
@@ -61,6 +61,7 @@ export default class extends BaseController {
       startOffset = 0;
     }
 
+    this.element.dataset.startOffset = startOffset.toString();
     this.resetToTimecode(startOffset);
     this.videoTarget.currentTime = startOffset;
   }

--- a/spec/system/vod_audience_spec.rb
+++ b/spec/system/vod_audience_spec.rb
@@ -100,7 +100,7 @@ describe "Prerecorded Audience View" do
       late_message.update!(timecode_ms: 8_999)
       visit path_for_video(video, t: 1)
       assert_video_is_playing(2)
-      expect(page).to have_css("[data-start-time='1']")
+      expect(page).to have_css("[data-start-offset='1']")
       expect(page).to have_content(ChatMessage.first.payload["message"])
 
       expect(page).to have_no_content(late_message.payload["message"], wait: 0)
@@ -109,7 +109,7 @@ describe "Prerecorded Audience View" do
       visit path_for_video(video, t: 9)
       assert_video_is_playing(9)
 
-      expect(page).to have_css("[data-start-time='9']")
+      expect(page).to have_css("[data-start-offset='9']")
       # Messages from before stream should show
       first_message = ChatMessage.first
       expect(first_message.timecode_ms).to eq(0)
@@ -124,7 +124,7 @@ describe "Prerecorded Audience View" do
       visit path_for_video(video)
 
       expect(page).to have_css("[data-start-offset='#{start_offset}']")
-      expect(page).to have_css("[data-start-time='#{start_offset}']")
+      expect(page).to have_css("[data-start-offset='#{start_offset}']")
       assert_video_is_playing
 
       # We actually have no clue where in the time code we'll be, but its safe


### PR DESCRIPTION
- Adjusts start offsets to fire on `durationchange` so they have a duration to actually work with. `loadedmetadata` would fire with no actual duration in place.